### PR TITLE
fix: deduplicate IPv4/IPv6 and internal port entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to portracker will be documented in this file.
 
+## [1.3.2] - 2026-02-03
+
+### Fixed
+
+- **Duplicate Ports**: Fixed duplicate port entries caused by IPv4/IPv6 wildcard addresses and internal port detection (resolves #82)
+
 ## [1.3.1] - 2026-02-03
 
 ### Fixed

--- a/backend/collectors/base_collector.js
+++ b/backend/collectors/base_collector.js
@@ -139,11 +139,15 @@ class BaseCollector {
    * @returns {Object} Normalized port entry
    */
   normalizePortEntry(entry) {
+    let hostIp = entry.host_ip || "0.0.0.0";
+    if (hostIp === "::" || hostIp === "[::]" || hostIp === "*") {
+      hostIp = "0.0.0.0";
+    }
     return {
       source: entry.source || this.platform,
       owner: entry.owner || "unknown",
       protocol: entry.protocol || "tcp",
-      host_ip: entry.host_ip || "0.0.0.0",
+      host_ip: hostIp,
       host_port: parseInt(entry.host_port, 10) || 0,
       target: entry.target || null,
       container_id: entry.container_id || null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portracker",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A multi-platform port-tracking dashboard",
   "main": "backend/index.js",
   "scripts": {


### PR DESCRIPTION
- **Duplicate Ports**: Fixed duplicate port entries caused by IPv4/IPv6 wildcard addresses and internal port detection (resolves #82)