### PR TITLE
fix: dedupe host-network service ports across collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to portracker will be documented in this file.
 
+## [1.3.4] - 2026-02-05
+
+### Fixed
+
+- **Host-Network Service Deduplication**: Added logical deduplication for services using host networking so the same listener is not shown multiple times when discovered through both Docker and process-based collection paths (addresses #82)
+- **Service Port Rendering**: Updated service view port keys to use full port identity, avoiding repeated port chips when entries share the same host port number
+
 ## [1.3.3] - 2026-02-05
 
 ### Fixed

--- a/backend/collectors/base_collector.js
+++ b/backend/collectors/base_collector.js
@@ -143,12 +143,24 @@ class BaseCollector {
     if (hostIp === "::" || hostIp === "[::]" || hostIp === "*") {
       hostIp = "0.0.0.0";
     }
+    const parsedPid = parseInt(entry.pid, 10);
+    const pid = Number.isNaN(parsedPid) ? null : parsedPid;
+    const pids = Array.isArray(entry.pids)
+      ? entry.pids
+          .map((candidatePid) => parseInt(candidatePid, 10))
+          .filter((candidatePid) => !Number.isNaN(candidatePid) && candidatePid > 0)
+      : pid
+        ? [pid]
+        : [];
+    const primaryPid = pid || pids[0] || null;
     return {
       source: entry.source || this.platform,
       owner: entry.owner || "unknown",
       protocol: entry.protocol || "tcp",
       host_ip: hostIp,
       host_port: parseInt(entry.host_port, 10) || 0,
+      pid: primaryPid,
+      pids,
       target: entry.target || null,
       container_id: entry.container_id || null,
       vm_id: entry.vm_id || null,

--- a/frontend/src/components/server/ServiceCardGrid.jsx
+++ b/frontend/src/components/server/ServiceCardGrid.jsx
@@ -125,7 +125,7 @@ export function ServiceCardGrid({
 
         <div className="flex flex-wrap gap-1.5 mb-3">
           {publishedPorts.map((port) => (
-            <React.Fragment key={port.host_port}>
+            <React.Fragment key={generatePortKey(serverId, port)}>
               <ClickablePortBadge
                 port={port}
                 serverId={serverId}

--- a/frontend/src/components/server/ServiceCardList.jsx
+++ b/frontend/src/components/server/ServiceCardList.jsx
@@ -139,7 +139,7 @@ export function ServiceCardList({
           {publishedPorts.map((port) => {
             const autoxposeData = getAutoxposeData(autoxposePorts, port);
             return (
-              <React.Fragment key={port.host_port}>
+              <React.Fragment key={`autoxpose-${generatePortKey(serverId, port)}`}>
                 {autoxposeData && autoxposeDisplayMode === "url" && (
                   <ExternalUrlChip
                     url={autoxposeData.url}
@@ -160,7 +160,7 @@ export function ServiceCardList({
           })}
           {publishedPorts.map((port) => (
             <ClickablePortBadge
-              key={`port-${port.host_port}`}
+              key={`badge-${generatePortKey(serverId, port)}`}
               port={port}
               serverId={serverId}
               serverUrl={serverUrl}

--- a/frontend/src/components/server/ServiceCardTable.jsx
+++ b/frontend/src/components/server/ServiceCardTable.jsx
@@ -109,7 +109,7 @@ export function ServiceCardTableRow({
         <td className="px-4 py-3">
           <div className="flex items-center space-x-1 flex-wrap gap-1">
             {publishedPorts.map((port) => (
-              <React.Fragment key={port.host_port}>
+              <React.Fragment key={generatePortKey(serverId, port)}>
                 <ClickablePortBadge
                   port={port}
                   serverId={serverId}

--- a/frontend/src/lib/whats-new-config.js
+++ b/frontend/src/lib/whats-new-config.js
@@ -1,6 +1,6 @@
 const whatsNewConfig = {
   combineWhatsNewGroups: [
-    { versions: ['1.3.1', '1.3.2', '1.3.3'], mergeTitles: ['Duplicate Ports'] }
+    { versions: ['1.3.1', '1.3.2', '1.3.3', '1.3.4'], mergeTitles: ['Duplicate Ports'] }
   ]
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portracker",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A multi-platform port-tracking dashboard",
   "main": "backend/index.js",
   "scripts": {


### PR DESCRIPTION
- **Host-Network Service Deduplication**: Added logical deduplication for services using host networking so the same listener is not shown multiple times when discovered through both Docker and process-based collection paths (addresses #82)
- **Service Port Rendering**: Updated service view port keys to use full port identity, avoiding repeated port chips when entries share the same host port number