### PR TITLE
fix: remove vulnerable sqlite3 system packages from Docker image (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to portracker will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.5] - 2026-03-02
+
+### Security
+
+- **Remove Vulnerable SQLite System Packages**: Removed unused `libsqlite3-dev` and `sqlite3` system packages from Docker image to address CVE-2025-7458. portracker uses `better-sqlite3` which bundles its own SQLite 3.49.2 (not affected) and never used the system libraries.
+
 ### Fixed
 
 - **TrueNAS API Key Transport Security**: Enforced secure WebSocket usage for TrueNAS API key authentication by restricting secure mode to `wss://` endpoints and skipping insecure `ws://` endpoints.
@@ -45,7 +51,7 @@ All notable changes to portracker will be documented in this file.
 
 ### Security
 
-- **API Key Authentication**: Secure peer-to-peer communication between Portracker instances
+- **API Key Authentication**: Secure peer-to-peer communication between portracker instances
   - **[sub]** Generate unique API keys for external access from Settings
   - **[sub]** Backward compatible - only required when remote server has authentication enabled
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get clean && \
     python3 \
     make \
     g++ \
-    libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy package files
@@ -52,7 +51,6 @@ RUN apt-get clean && \
     docker.io \
     netcat-openbsd \
     wget \
-    sqlite3 \
     procps \
     util-linux \
     && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portracker",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A multi-platform port-tracking dashboard",
   "main": "backend/index.js",
   "scripts": {


### PR DESCRIPTION
**Remove Vulnerable SQLite System Packages**: Removed unused `libsqlite3-dev` and `sqlite3` system packages from Docker image to address CVE-2025-7458. portracker uses `better-sqlite3` which bundles its own `SQLite 3.49.2` (not affected) and never used the system libraries.