### PR TITLE
Status indicator overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agents — portracker
+
+See `dev/AGENTS.md` for the full workflow contract. Highlights for this repo:
+
+- Backend: `backend/index.js` + `backend/collectors/`, `backend/routes/`
+- Frontend: Vite + React in `frontend/` (Tailwind + shadcn-style components)
+- Containerized via root `Dockerfile` and `docker-compose.yml`
+
+## Task tracking — `bd` is mandatory
+
+Use the global Beads DB at `/data/beads/.beads`. Do not create ad-hoc TODO markdown.
+
+```sh
+bd ready --json                   # start every session here
+bd create "Title" -p 1 -t task
+bd update <id> --claim
+bd update <id> --notes "..."
+bd close <id> --reason "..."
+```
+
+Tag portracker work with `--label portracker` or `[portracker]` in the title:
+
+```sh
+bd list --label portracker --status open --json
+```
+
+Full rules: see `dev/AGENTS.md` → "Task tracking — `bd` (Beads) is mandatory".
+
+## Repo-specific guardrails
+
+- UI changes need visual verification via Playwright (compare prod `:30233` vs dev `:4998`).
+- Dismiss the "What's New" modal in screenshots (see user memory: `playwright-mcp-stdio.md`).
+- Never restart the production portracker container without explicit approval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to portracker will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **[Sidebar Controls]**: Desktop sidebar can now be resized, collapsed to a cleaner icon rail, and rediscovered with a one-time coachmark that points out the new controls.
+- **[Keyboard Shortcuts]**: `Cmd/Ctrl+K` focuses search, `Escape` clears and blurs, `Cmd/Ctrl+B` toggles the sidebar, `Cmd/Ctrl+R` refreshes, and `1`–`9` quick-switch between servers.
+- **[Server Health Indicator]**: Server cards in the sidebar now show a colored dot (green = online, red = unreachable, blue pulse = updating).
+- **[Last Refreshed Timestamp]**: Each server card displays a live-updating "Updated Xm ago" label showing when data was last fetched.
+
 ## [1.3.7] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to portracker will be documented in this file.
 - **[Server Health Indicator]**: Server cards in the sidebar now show a colored dot (green = online, red = unreachable, blue pulse = updating).
 - **[Last Refreshed Timestamp]**: Each server card displays a live-updating "Updated Xm ago" label showing when data was last fetched.
 
+### Fixed
+
+- **[Status Dot Spacing]**: Restored the gap between the rolled-up service status dot and the service name in card headers.
+- **[Status Wording]**: Updated copy on per-port indicators, the rolled-up status dot, and the "Why this status?" details so a published port that isn't reachable now reads clearly instead of using ambiguous "did not answer" / "not responding" phrasing.
+- **[Status Dot Loading State]**: Service cards now show a soft pulsing dot while service health data is loading instead of briefly flashing red on services whose published ports were partially unreachable.
+- **[Service Card Grouping]**: Containers that publish multiple ports now consolidate into a single service card instead of splitting into several rows when their compose labels were inconsistent across collection paths.
+
 ## [1.3.7] - 2026-04-02
 
 ### Fixed

--- a/backend/collectors/docker_collector.js
+++ b/backend/collectors/docker_collector.js
@@ -219,7 +219,6 @@ class DockerCollector extends BaseCollector {
     }
   }
 
-
   /**
    * Get Docker applications (containers)
    * @returns {Promise<Array>} List of applications
@@ -388,10 +387,9 @@ class DockerCollector extends BaseCollector {
         } catch (systemErr) {
           this.logWarn("Failed to collect and process system ports:", systemErr.message);
         }
-
         const collapsedPorts = this._collapseDockerLogicalDuplicates(allPorts);
-        const deduplicatedPorts =
-          this._collapseProcessLogicalDuplicates(collapsedPorts);
+        const deduplicatedPorts = this._collapseProcessLogicalDuplicates(collapsedPorts);
+        await require("../lib/docker/compose-attribution").enrichComposeLabels(this.dockerApi, deduplicatedPorts, this.logWarn.bind(this));
         this.logInfo(`Total unique ports collected: ${deduplicatedPorts.length}`);
         return deduplicatedPorts;
       } catch (err) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -19,6 +19,7 @@ const authRoutes = require('./routes/auth');
 const settingsRoutes = require('./routes/settings');
 const autoxposeRoutes = require('./routes/autoxpose');
 const recoveryManager = require('./lib/recovery-manager');
+const { enrichComposeLabelsOnPorts: enrichComposeLabelsOnPortsImpl } = require('./lib/docker/compose-attribution');
 
 const logger = new Logger("Server", { debug: process.env.DEBUG === 'true' });
 const BASE_DEBUG = process.env.DEBUG === 'true';
@@ -45,7 +46,6 @@ const pingDebugStats = {
   startTime: Date.now(),
   lastSummaryTime: Date.now()
 };
-
 
 function logPingDebug(message, force = false) {
   pingDebugStats.count++;
@@ -154,7 +154,6 @@ function getDockerHostIP() {
   return "172.17.0.1";
 }
 
-
 function isDockerDesktopEnvironment() {
   try {
     if (process.env.DOCKER_DESKTOP === 'true') {
@@ -197,7 +196,6 @@ function isDockerDesktopEnvironment() {
     return false;
   }
 }
-
 
 async function testProtocol(scheme, host_ip, port, path = "/", isDebugEnabled = false) {
   const controller = new AbortController();
@@ -365,17 +363,6 @@ async function testProtocol(scheme, host_ip, port, path = "/", isDebugEnabled = 
   }
 }
 
-
-/**
- * Determines the status and accessibility of a service based on its type and HTTP(S) response data.
- *
- * Evaluates the service type and the results of HTTP and HTTPS protocol checks to classify the service as accessible, listening, unreachable, or in error. Returns a status object with color coding, descriptive title, and protocol information when applicable.
- *
- * @param {Object} serviceInfo - Metadata about the service, including type, name, and description.
- * @param {Object} httpsResponse - Result of the HTTPS protocol check, including reachability and status code.
- * @param {Object} httpResponse - Result of the HTTP protocol check, including reachability and status code.
- * @return {Object} An object describing the service's status, color, title, description, and protocol if relevant.
- */
 function determineServiceStatus(serviceInfo, httpsResponse, httpResponse) {
   const serviceType = serviceInfo.type;
   
@@ -611,9 +598,6 @@ app.use('/api/autoxpose', autoxposeRoutes);
 
 const PORT = process.env.PORT || 3000;
 
-/**
- * Get all ports from the local system using the collector framework.
- */
 app.get("/api/ports", requireAuthOrApiKey, async (req, res) => {
   const debug = req.query.debug === "true";
   if (Object.prototype.hasOwnProperty.call(req.query, 'debug')) logger.setDebugEnabled(debug);
@@ -678,9 +662,6 @@ app.get("/api/ports", requireAuthOrApiKey, async (req, res) => {
   }
 });
 
-/**
- * New peer-based endpoint to replace remote API connectivity.
- */
 app.get("/api/all-ports", requireAuthOrApiKey, async (req, res) => {
   const debug = req.query.debug === "true" || process.env.DEBUG === 'true';
   if (Object.prototype.hasOwnProperty.call(req.query, 'debug')) logger.setDebugEnabled(debug);
@@ -725,12 +706,11 @@ app.get("/api/all-ports", requireAuthOrApiKey, async (req, res) => {
   }
 });
 
-/**
- * Collects and returns the list of open ports on the local system using the most suitable platform-specific collector.
- * @param {Object} [options] - Optional settings for port collection.
- * @param {boolean} [options.debug] - Enables debug logging if true.
- * @return {Promise<Array>} Resolves with an array of port information objects.
- */
+app.get("/api/services", requireAuthOrApiKey, require('./routes/services').createServicesHandler({
+  getLocalPortsUsingCollectors: (...a) => getLocalPortsUsingCollectors(...a),
+  dockerApi, logger, baseDebug: BASE_DEBUG,
+}));
+
 async function getLocalPortsUsingCollectors(options = {}) {
   const currentDebug = options.debug || false;
 
@@ -742,13 +722,19 @@ async function getLocalPortsUsingCollectors(options = {}) {
 
     const ports = await collector.getPorts();
     logger.debug(`[getLocalPortsUsingCollectors] Collected ${ports?.length || 0} ports.`);
-    
+
+    await enrichComposeLabelsOnPorts(ports);
+
     return ports;
   } catch (error) {
     logger.error("[getLocalPortsUsingCollectors] Primary collection attempt failed:", error.message);
     logger.debug("Stack trace:", error.stack || "");
     throw error;
   }
+}
+
+async function enrichComposeLabelsOnPorts(ports) {
+  return enrichComposeLabelsOnPortsImpl(dockerApi, ports, logger);
 }
 
 function getPortRangeForSuggestion() {
@@ -889,9 +875,6 @@ async function generateUnusedPortFromPortList(portEntries, { bindCheck = false, 
   return generateUnusedPortWithSet(usedPorts, { bindCheck, method });
 }
 
-/**
- * New endpoint to scan a server with the appropriate collector
- */
 app.get("/api/servers/:id/scan", requireAuthOrApiKey, async (req, res) => {
   const serverId = req.params.id;
   const currentDebug = req.query.debug === "true" || process.env.DEBUG === 'true';
@@ -953,6 +936,8 @@ app.get("/api/servers/:id/scan", requireAuthOrApiKey, async (req, res) => {
       const collectData = await collector.collectAll();
 
       if (collectData.ports && Array.isArray(collectData.ports)) {
+        await enrichComposeLabelsOnPorts(collectData.ports);
+
         const enrichedPorts = collectData.ports.map((port) => {
           const internalFlag = port.internal ? 1 : 0;
           const noteEntry = db
@@ -1083,11 +1068,6 @@ app.get("/api/servers/:id/scan", requireAuthOrApiKey, async (req, res) => {
   }
 });
 
-/**
- * Generate an unused TCP port for the given server.
- * - For local: uses collectors to find used ports, excludes well-known/reserved, then validates with a TCP bind test.
- * - For peers: forwards the request to the peer's /api/servers/local/generate-port endpoint.
- */
 app.post("/api/servers/:id/generate-port", async (req, res) => {
   const serverId = req.params.id;
   const currentDebug = req.query.debug === "true" || process.env.DEBUG === 'true';
@@ -1305,10 +1285,6 @@ function validateNoteInput(req, res, next) {
   next();
 }
 
-/**
- * Middleware that validates the presence and format of the server ID parameter in the request.
- * Responds with a 400 error if the ID is missing or not a non-empty string.
- */
 function validateServerIdParam(req, res, next) {
   const serverId = req.params.id;
   if (
@@ -1328,10 +1304,6 @@ function validateServerIdParam(req, res, next) {
   next();
 }
 
-/**
- * Middleware that validates input for custom service name operations.
- * Validates server_id, host_ip, host_port, custom_name, and container_id fields.
- */
 function validateCustomServiceNameInput(req, res, next) {
   const { server_id, host_ip, host_port, protocol, custom_name, container_id, internal } = req.body;
 
@@ -1408,10 +1380,6 @@ function validateCustomServiceNameInput(req, res, next) {
   next();
 }
 
-/**
- * Middleware that validates input for ignore operations.
- * Validates server_id, host_ip, host_port, protocol, ignored, and container_id fields.
- */
 function validateIgnoreInput(req, res, next) {
   const { server_id, host_ip, host_port, protocol, ignored, container_id, internal } = req.body;
 
@@ -1488,10 +1456,6 @@ function validateIgnoreInput(req, res, next) {
   next();
 }
 
-/**
- * Middleware that validates input for custom service name delete operations.
- * Validates server_id, host_ip, host_port, protocol, and container_id fields.
- */
 function validateCustomServiceNameDeleteInput(req, res, next) {
   const { server_id, host_ip, host_port, protocol, container_id, internal } = req.body;
 
@@ -2043,10 +2007,6 @@ app.delete("/api/custom-service-names", requireAuth, validateCustomServiceNameDe
 
     let deletedCount = result.changes;
 
-    /**
-     * If no rows were deleted and we have a container_id, try deleting without container_id
-     * This handles legacy records that were created before container_id support
-     */
     if (deletedCount === 0 && container_id) {
       const legacyResult = db
         .prepare("DELETE FROM custom_service_names WHERE server_id = ? AND host_ip = ? AND host_port = ? AND protocol = ? AND container_id IS NULL AND internal = ?")
@@ -2449,7 +2409,7 @@ app.get("/api/ping", requireAuthOrApiKey, async (req, res) => {
       host_ip === "[::1]")
   ) {
     if (isInDocker) {
-      const dockerHostIP = getDockerHostIP();
+      const dockerHostIP = HOST_OVERRIDE || getDockerHostIP();
       pingable_host_ip = dockerHostIP;
       logPingDebug(
         `Detected Docker environment, using host IP '${dockerHostIP}' for port ${host_port}`

--- a/backend/index.js
+++ b/backend/index.js
@@ -711,6 +711,13 @@ app.get("/api/services", requireAuthOrApiKey, require('./routes/services').creat
   dockerApi, logger, baseDebug: BASE_DEBUG,
 }));
 
+const servicesRoutes = require('./routes/services');
+app.get("/api/overrides", requireAuthOrApiKey, servicesRoutes.createGetOverridesHandler({ logger }));
+app.put("/api/services/:serviceId/components/:componentId/role", requireAuthOrApiKey, servicesRoutes.createPutOverrideHandler({ logger }));
+app.delete("/api/services/:serviceId/components/:componentId/role", requireAuthOrApiKey, servicesRoutes.createDeleteOverrideHandler({ logger }));
+app.delete("/api/services/:serviceId/overrides", requireAuthOrApiKey, servicesRoutes.createDeleteServiceOverridesHandler({ logger }));
+app.delete("/api/overrides", requireAuthOrApiKey, servicesRoutes.createDeleteAllOverridesHandler({ logger }));
+
 async function getLocalPortsUsingCollectors(options = {}) {
   const currentDebug = options.debug || false;
 

--- a/backend/lib/docker/compose-attribution.js
+++ b/backend/lib/docker/compose-attribution.js
@@ -1,0 +1,99 @@
+async function enrichComposeLabels(dockerApi, entries, logWarn) {
+  if (!Array.isArray(entries) || entries.length === 0) return;
+  const uniqueIds = new Set();
+  for (const e of entries) if (e && e.container_id) uniqueIds.add(e.container_id);
+  if (uniqueIds.size === 0) return;
+  const labelsById = new Map();
+  for (const id of uniqueIds) {
+    try {
+      const inspection = await dockerApi.inspectContainer(id);
+      const labels = (inspection && inspection.Config && inspection.Config.Labels) || {};
+      labelsById.set(id, {
+        composeProject: labels['com.docker.compose.project'] || null,
+        composeService: labels['com.docker.compose.service'] || null,
+      });
+    } catch (err) {
+      logWarn(`compose-label enrichment failed for ${id}:`, err.message);
+    }
+  }
+  for (const entry of entries) {
+    if (!entry || !entry.container_id) continue;
+    const info = labelsById.get(entry.container_id);
+    if (!info) continue;
+    if (info.composeProject) entry.compose_project = info.composeProject;
+    if (info.composeService) entry.compose_service = info.composeService;
+  }
+}
+
+module.exports = { enrichComposeLabels, enrichComposeLabelsOnPorts };
+
+async function enrichComposeLabelsOnPorts(dockerApi, ports, logger) {
+  if (!Array.isArray(ports) || ports.length === 0) return;
+  const uniqueIds = new Set();
+  for (const port of ports) if (port && port.container_id) uniqueIds.add(port.container_id);
+  const labelsById = new Map();
+  let inspectFailures = 0;
+  let dockerAvailable = uniqueIds.size > 0;
+  if (dockerAvailable) {
+    try {
+      if (typeof dockerApi._ensureConnected === 'function') await dockerApi._ensureConnected();
+    } catch (_err) {
+      dockerAvailable = false;
+    }
+  }
+  if (dockerAvailable) {
+    for (const id of uniqueIds) {
+      try {
+        const inspection = await dockerApi.inspectContainer(id);
+        const labels = (inspection && inspection.Config && inspection.Config.Labels) || {};
+        const networks = inspection && inspection.NetworkSettings && inspection.NetworkSettings.Networks;
+        const networkNames = networks ? Object.keys(networks) : [];
+        const defaultNetwork = networkNames.find((networkName) => networkName.endsWith('_default'));
+        labelsById.set(id, {
+          composeProject: labels['com.docker.compose.project'] || (defaultNetwork ? defaultNetwork.replace(/_default$/, '') : null),
+          composeService: labels['com.docker.compose.service'] || null,
+        });
+      } catch (err) {
+        inspectFailures++;
+        logger.debug(`[enrichComposeLabels] inspect failed for ${id}: ${err.message}`);
+      }
+    }
+  }
+  let mutations = 0;
+  for (const port of ports) {
+    if (!port || !port.container_id) continue;
+    const info = labelsById.get(port.container_id);
+    if (!info) continue;
+    if (info.composeProject && port.compose_project !== info.composeProject) {
+      port.compose_project = info.composeProject;
+      mutations++;
+    }
+    if (info.composeService && port.compose_service !== info.composeService) {
+      port.compose_service = info.composeService;
+    }
+  }
+  const knownProjects = Array.from(
+    new Set(ports.map((port) => port && port.compose_project).filter(Boolean))
+  ).sort((a, b) => b.length - a.length);
+  for (const port of ports) {
+    if (!port || port.source !== 'docker' || !port.owner) continue;
+    if (port.compose_project && port.compose_service) continue;
+    if (!/-\d+$/.test(port.owner)) continue;
+    const project = port.compose_project || knownProjects.find((candidate) => port.owner.startsWith(`${candidate}-`));
+    if (!project) continue;
+    if (!port.owner.startsWith(`${project}-`)) continue;
+    const service = port.owner.slice(project.length + 1).replace(/-\d+$/, '');
+    if (!port.compose_project) {
+      port.compose_project = project;
+      mutations++;
+    }
+    if (service && !port.compose_service) {
+      port.compose_service = service;
+      mutations++;
+    }
+  }
+  logger.debug(
+    `[enrichComposeLabels] entries=${ports.length} cids=${uniqueIds.size} ` +
+    `resolved=${labelsById.size} inspect_failures=${inspectFailures} mutations=${mutations}`
+  );
+}

--- a/backend/lib/health/aggregate.js
+++ b/backend/lib/health/aggregate.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { ROLES } = require('./classify');
+
+const CORE_ROLES = new Set([ROLES.CORE_RUNTIME, ROLES.CORE_ACCESS]);
+
+function componentSucceeded(entry) {
+  const probe = entry && entry.probe;
+  if (!probe) return null;
+  return probe.ok === true;
+}
+
+function summarizeComponent(entry) {
+  const classification = entry && entry.classification ? entry.classification : {};
+  const probe = entry && entry.probe ? entry.probe : {};
+  return {
+    componentId: entry && entry.componentId ? entry.componentId : null,
+    role: classification.role || ROLES.UNKNOWN,
+    ruleId: classification.ruleId || null,
+    confidence: classification.confidence || null,
+    reason: classification.reason || null,
+    probe: {
+      ok: probe.ok === true,
+      severity: probe.severity || null,
+      latencyMs: Number.isFinite(probe.latencyMs) ? probe.latencyMs : null,
+      error: probe.error || null,
+      evidence: probe.evidence || null,
+    },
+    containerId: entry && entry.signals && entry.signals.containerId
+      ? entry.signals.containerId
+      : (entry && entry.containerId) || null,
+  };
+}
+
+function aggregate(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  if (list.length === 0) {
+    return {
+      color: 'gray',
+      reason: 'no components observed',
+      failingComponents: [],
+      components: [],
+      evidence: [],
+    };
+  }
+
+  const components = list.map(summarizeComponent);
+
+  const core = [];
+  const support = [];
+  const jobs = [];
+  const unknown = [];
+
+  components.forEach((c) => {
+    if (CORE_ROLES.has(c.role)) core.push(c);
+    else if (c.role === ROLES.SUPPORT) support.push(c);
+    else if (c.role === ROLES.JOB_EXPECTED_EXIT) jobs.push(c);
+    else unknown.push(c);
+  });
+
+  const coreFailures = core.filter((c) => c.probe.ok !== true);
+  const corePartial = core.filter((c) => c.probe.ok === true && c.probe.severity === 'yellow');
+  const supportFailures = support.filter((c) => c.probe.ok !== true);
+  const unknownFailures = unknown.filter((c) => c.probe.ok !== true);
+
+  let color;
+  let reason;
+
+  if (core.length > 0 && coreFailures.length > 0) {
+    color = 'red';
+    reason = `main service${coreFailures.length > 1 ? 's' : ''} failing: ${coreFailures.map((c) => c.componentId || c.role).join(', ')}`;
+  } else if (core.length > 0 && corePartial.length > 0) {
+    color = 'yellow';
+    const detail = corePartial.map((c) => c.probe.error).filter(Boolean).join('; ');
+    reason = detail || `core partially reachable: ${corePartial.map((c) => c.componentId).join(', ')}`;
+  } else if (core.length > 0 && (supportFailures.length > 0 || unknownFailures.length > 0)) {
+    color = 'yellow';
+    const degraded = supportFailures.concat(unknownFailures);
+    reason = `main service reachable; helper issue: ${degraded.map((c) => c.componentId || c.role).join(', ')}`;
+  } else if (core.length > 0) {
+    color = 'green';
+    reason = 'Main service is reachable';
+  } else if (unknown.length > 0) {
+    color = 'gray';
+    reason = 'No main service identified; set a role if needed';
+  } else if (jobs.length > 0 && support.length === 0) {
+    color = 'gray';
+    reason = 'only expected-exit jobs observed';
+  } else if (support.length > 0 && supportFailures.length === 0) {
+    color = 'gray';
+    reason = 'No main service identified; helper services are reachable';
+  } else {
+    color = 'gray';
+    reason = 'insufficient signal';
+  }
+
+  const failingComponents = coreFailures
+    .concat(supportFailures)
+    .concat(unknownFailures)
+    .map((c) => c.componentId || c.role);
+
+  const evidence = components.map((c) => ({
+    componentId: c.componentId,
+    role: c.role,
+    ruleId: c.ruleId,
+    ok: c.probe.ok,
+    error: c.probe.error,
+    reason: c.reason,
+  }));
+
+  return {
+    color,
+    reason,
+    failingComponents,
+    components,
+    evidence,
+  };
+}
+
+module.exports = {
+  aggregate,
+  componentSucceeded,
+};

--- a/backend/lib/health/aggregate.js
+++ b/backend/lib/health/aggregate.js
@@ -37,7 +37,7 @@ function aggregate(entries) {
   if (list.length === 0) {
     return {
       color: 'gray',
-      reason: 'no components observed',
+      reason: 'No components found.',
       failingComponents: [],
       components: [],
       evidence: [],
@@ -68,33 +68,32 @@ function aggregate(entries) {
 
   if (core.length > 0 && coreFailures.length > 0) {
     color = 'red';
-    reason = `main service${coreFailures.length > 1 ? 's' : ''} failing: ${coreFailures.map((c) => c.componentId || c.role).join(', ')}`;
+    reason = 'Main service unreachable.';
   } else if (core.length > 0 && corePartial.length > 0) {
     color = 'yellow';
     const detail = corePartial.map((c) => c.probe.error).filter(Boolean).join('; ');
-    reason = detail || `core partially reachable: ${corePartial.map((c) => c.componentId).join(', ')}`;
+    reason = detail || 'Service is partially reachable.';
   } else if (core.length > 0 && (supportFailures.length > 0 || unknownFailures.length > 0)) {
     color = 'yellow';
-    const degraded = supportFailures.concat(unknownFailures);
-    reason = `main service reachable; helper issue: ${degraded.map((c) => c.componentId || c.role).join(', ')}`;
+    reason = 'Main service reachable, but a helper has issues.';
   } else if (core.length > 0) {
     color = 'green';
-    reason = 'Main service is reachable';
+    reason = 'Main service is reachable.';
   } else if (unknown.length > 0) {
     color = 'gray';
-    reason = 'No main service identified; set a role if needed';
+    reason = 'No main service identified — set a role if needed.';
   } else if (jobs.length > 0 && support.length === 0) {
     color = 'gray';
-    reason = 'only expected-exit jobs observed';
+    reason = 'Only finished jobs observed.';
   } else if (support.length > 0 && supportFailures.length > 0) {
     color = 'gray';
-    reason = 'No main service identified; a helper component is failing. Set a role to get a verdict.';
+    reason = 'No main service identified, and a helper is failing. Pick a role to get a verdict.';
   } else if (support.length > 0 && supportFailures.length === 0) {
     color = 'gray';
-    reason = 'No main service identified; helper services are reachable';
+    reason = 'No main service identified; helper services are reachable.';
   } else {
     color = 'gray';
-    reason = 'insufficient signal';
+    reason = 'Not enough info to judge.';
   }
 
   const failingComponents = coreFailures

--- a/backend/lib/health/aggregate.js
+++ b/backend/lib/health/aggregate.js
@@ -86,6 +86,9 @@ function aggregate(entries) {
   } else if (jobs.length > 0 && support.length === 0) {
     color = 'gray';
     reason = 'only expected-exit jobs observed';
+  } else if (support.length > 0 && supportFailures.length > 0) {
+    color = 'gray';
+    reason = 'No main service identified; a helper component is failing. Set a role to get a verdict.';
   } else if (support.length > 0 && supportFailures.length === 0) {
     color = 'gray';
     reason = 'No main service identified; helper services are reachable';

--- a/backend/lib/health/classify.js
+++ b/backend/lib/health/classify.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const ROLES = Object.freeze({
+  CORE_RUNTIME: 'core_runtime',
+  CORE_ACCESS: 'core_access',
+  SUPPORT: 'support',
+  JOB_EXPECTED_EXIT: 'job_expected_exit',
+  UNKNOWN: 'unknown',
+});
+
+function result(role, confidence, reason, ruleId) {
+  return { role, confidence, reason, ruleId };
+}
+
+function classify(signals, context) {
+  const s = signals || {};
+  const ctx = context || {};
+
+  if (ctx.override && typeof ctx.override === 'string') {
+    return result(ctx.override, 'override', 'user override', 'R2');
+  }
+
+  if (s.hasHealthcheck && s.healthcheckStatus) {
+    const hs = String(s.healthcheckStatus).toLowerCase();
+    if (hs === 'healthy') {
+      return result(ROLES.CORE_ACCESS, 'high', 'container reports healthy', 'R1');
+    }
+    if (hs === 'unhealthy') {
+      return result(ROLES.CORE_ACCESS, 'high', 'container reports unhealthy', 'R1');
+    }
+    if (hs === 'starting') {
+      return result(ROLES.CORE_ACCESS, 'medium', 'container is still starting', 'R1');
+    }
+  }
+
+  const deps = Array.isArray(s.dependsOn) ? s.dependsOn : [];
+  if (s.composeService && deps.length > 0 && Array.isArray(ctx.siblingServices) && ctx.siblingServices.length > 0) {
+    const isDependency = ctx.siblingServices.some((sib) => deps.includes(sib));
+    if (isDependency) {
+      return result(ROLES.SUPPORT, 'medium', `${s.composeService} is depended on by siblings; treat as support`, 'R3');
+    }
+  }
+  if (ctx.siblingDependsOnUs === true) {
+    return result(ROLES.SUPPORT, 'medium', 'compose depends_on: other services depend on this one', 'R3');
+  }
+
+  if (s.isOnlyPublishedPort === true) {
+    return result(ROLES.CORE_ACCESS, 'high', 'only published port of the service', 'R4');
+  }
+
+  const proto = String(s.protocol || '').toLowerCase();
+  const bound = String(s.boundTo || '').toLowerCase();
+  if (proto === 'udp' && ctx.serviceHasHttpResponder === true) {
+    return result(ROLES.SUPPORT, 'medium', 'UDP port alongside an HTTP-responding sibling port', 'R5');
+  }
+  if (bound === 'loopback') {
+    return result(ROLES.SUPPORT, 'medium', 'bound to loopback only; not user-facing', 'R5');
+  }
+
+  const restart = String(s.restartPolicy || 'no').toLowerCase();
+  if (s.containerState === 'exited' && s.exitCode === 0 && (restart === 'no' || restart === 'on-failure')) {
+    return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'container exited 0 with non-always restart policy', 'R6');
+  }
+
+  const hints = s.imageHints || {};
+  if (hints.isExporterLike) {
+    return result(ROLES.SUPPORT, 'low', 'image name hints exporter/metrics/sidecar', 'R7');
+  }
+  if (hints.isProxyLike && s.isOnlyPublishedPort === true) {
+    return result(ROLES.CORE_ACCESS, 'low', 'image name hints proxy and is sole published port', 'R7');
+  }
+
+  return result(ROLES.UNKNOWN, 'low', 'no matching rule; user override recommended', 'R8');
+}
+
+module.exports = {
+  classify,
+  ROLES,
+};

--- a/backend/lib/health/classify.js
+++ b/backend/lib/health/classify.js
@@ -12,81 +12,93 @@ function result(role, confidence, reason, ruleId) {
   return { role, confidence, reason, ruleId };
 }
 
+const ROLE_LABELS = {
+  [ROLES.CORE_RUNTIME]: 'main service',
+  [ROLES.CORE_ACCESS]: 'main service',
+  [ROLES.SUPPORT]: 'helper',
+  [ROLES.JOB_EXPECTED_EXIT]: 'finished job',
+  [ROLES.UNKNOWN]: 'unknown',
+};
+
+function roleLabel(role) {
+  return ROLE_LABELS[role] || 'unknown';
+}
+
 function classify(signals, context) {
   const s = signals || {};
   const ctx = context || {};
 
   if (ctx.override && typeof ctx.override === 'string') {
-    return result(ctx.override, 'override', 'user override', 'R2');
+    return result(ctx.override, 'override', `Marked as ${roleLabel(ctx.override)} by you.`, 'R2');
   }
 
   if (s.hasHealthcheck && s.healthcheckStatus && s.containerState === 'running') {
     const hs = String(s.healthcheckStatus).toLowerCase();
     if (hs === 'healthy') {
-      return result(ROLES.CORE_ACCESS, 'high', 'container reports healthy', 'R1');
+      return result(ROLES.CORE_ACCESS, 'high', 'Container is healthy.', 'R1');
     }
     if (hs === 'unhealthy') {
-      return result(ROLES.CORE_ACCESS, 'high', 'container reports unhealthy', 'R1');
+      return result(ROLES.CORE_ACCESS, 'high', 'Container is unhealthy.', 'R1');
     }
     if (hs === 'starting') {
-      return result(ROLES.CORE_ACCESS, 'medium', 'container is still starting', 'R1');
+      return result(ROLES.CORE_ACCESS, 'medium', 'Container is still starting.', 'R1');
     }
   }
   if (s.hasHealthcheck && s.containerState === 'created') {
-    return result(ROLES.CORE_ACCESS, 'high', 'container has not started', 'R1');
+    return result(ROLES.CORE_ACCESS, 'high', 'Container has not started.', 'R1');
   }
   if (s.hasHealthcheck && s.containerState === 'restarting') {
-    return result(ROLES.CORE_ACCESS, 'medium', 'container is restarting', 'R1');
+    return result(ROLES.CORE_ACCESS, 'medium', 'Container is restarting.', 'R1');
   }
   if (s.hasHealthcheck && s.containerState === 'exited') {
     const restart = String(s.restartPolicy || 'no').toLowerCase();
     if (s.exitCode === 0 && (restart === 'no' || restart === 'on-failure')) {
-      return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'container exited 0 with non-always restart policy', 'R6');
+      return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'Finished cleanly (exit 0); no auto-restart configured.', 'R6');
     }
-    return result(ROLES.CORE_ACCESS, 'high', 'container has exited', 'R1');
+    return result(ROLES.CORE_ACCESS, 'high', 'Container has exited.', 'R1');
   }
   if (s.hasHealthcheck && s.containerState === 'dead') {
-    return result(ROLES.CORE_ACCESS, 'high', 'container is dead', 'R1');
+    return result(ROLES.CORE_ACCESS, 'high', 'Container is dead.', 'R1');
   }
 
   const deps = Array.isArray(s.dependsOn) ? s.dependsOn : [];
   if (s.composeService && deps.length > 0 && Array.isArray(ctx.siblingServices) && ctx.siblingServices.length > 0) {
     const isDependency = ctx.siblingServices.some((sib) => deps.includes(sib));
     if (isDependency) {
-      return result(ROLES.SUPPORT, 'medium', `${s.composeService} is depended on by siblings; treat as support`, 'R3');
+      return result(ROLES.SUPPORT, 'medium', 'Other compose services depend on this one — treated as a helper.', 'R3');
     }
   }
   if (ctx.siblingDependsOnUs === true) {
-    return result(ROLES.SUPPORT, 'medium', 'compose depends_on: other services depend on this one', 'R3');
+    return result(ROLES.SUPPORT, 'medium', 'Other compose services depend on this one — treated as a helper.', 'R3');
   }
 
   if (s.isOnlyPublishedPort === true) {
-    return result(ROLES.CORE_ACCESS, 'high', 'only published port of the service', 'R4');
+    return result(ROLES.CORE_ACCESS, 'high', 'The only port this service publishes — treated as the main service.', 'R4');
   }
 
   const proto = String(s.protocol || '').toLowerCase();
   const bound = String(s.boundTo || '').toLowerCase();
   if (proto === 'udp' && ctx.serviceHasHttpResponder === true) {
-    return result(ROLES.SUPPORT, 'medium', 'UDP port alongside an HTTP-responding sibling port', 'R5');
+    return result(ROLES.SUPPORT, 'medium', "UDP port alongside the service's HTTP port — treated as a helper.", 'R5');
   }
   if (bound === 'loopback') {
-    return result(ROLES.SUPPORT, 'medium', 'bound to loopback only; not user-facing', 'R5');
+    return result(ROLES.SUPPORT, 'medium', 'Only listens on 127.0.0.1 — treated as a helper.', 'R5');
   }
 
   const restart = String(s.restartPolicy || 'no').toLowerCase();
   if (s.containerState === 'exited' && s.exitCode === 0 && (restart === 'no' || restart === 'on-failure')) {
-    return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'container exited 0 with non-always restart policy', 'R6');
+    return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'Finished cleanly (exit 0); no auto-restart configured.', 'R6');
   }
 
   const hints = s.imageHints || {};
   if (hints.isExporterLike) {
-    return result(ROLES.SUPPORT, 'low', 'image name hints exporter/metrics/sidecar', 'R7');
+    return result(ROLES.SUPPORT, 'low', 'Image name suggests a metrics or sidecar helper.', 'R7');
   }
   if (hints.isProxyLike && s.isOnlyPublishedPort === true) {
-    return result(ROLES.CORE_ACCESS, 'low', 'image name hints proxy and is sole published port', 'R7');
+    return result(ROLES.CORE_ACCESS, 'low', 'Image name suggests a proxy, and this is the only published port — treated as the main service.', 'R7');
   }
 
-  return result(ROLES.UNKNOWN, 'low', 'no matching rule; user override recommended', 'R8');
+  return result(ROLES.UNKNOWN, 'low', "Couldn't tell if this is a main service or a helper. Use the dropdown to set it.", 'R8');
 }
 
 module.exports = {

--- a/backend/lib/health/classify.js
+++ b/backend/lib/health/classify.js
@@ -20,7 +20,7 @@ function classify(signals, context) {
     return result(ctx.override, 'override', 'user override', 'R2');
   }
 
-  if (s.hasHealthcheck && s.healthcheckStatus) {
+  if (s.hasHealthcheck && s.healthcheckStatus && s.containerState === 'running') {
     const hs = String(s.healthcheckStatus).toLowerCase();
     if (hs === 'healthy') {
       return result(ROLES.CORE_ACCESS, 'high', 'container reports healthy', 'R1');
@@ -31,6 +31,22 @@ function classify(signals, context) {
     if (hs === 'starting') {
       return result(ROLES.CORE_ACCESS, 'medium', 'container is still starting', 'R1');
     }
+  }
+  if (s.hasHealthcheck && s.containerState === 'created') {
+    return result(ROLES.CORE_ACCESS, 'high', 'container has not started', 'R1');
+  }
+  if (s.hasHealthcheck && s.containerState === 'restarting') {
+    return result(ROLES.CORE_ACCESS, 'medium', 'container is restarting', 'R1');
+  }
+  if (s.hasHealthcheck && s.containerState === 'exited') {
+    const restart = String(s.restartPolicy || 'no').toLowerCase();
+    if (s.exitCode === 0 && (restart === 'no' || restart === 'on-failure')) {
+      return result(ROLES.JOB_EXPECTED_EXIT, 'medium', 'container exited 0 with non-always restart policy', 'R6');
+    }
+    return result(ROLES.CORE_ACCESS, 'high', 'container has exited', 'R1');
+  }
+  if (s.hasHealthcheck && s.containerState === 'dead') {
+    return result(ROLES.CORE_ACCESS, 'high', 'container is dead', 'R1');
   }
 
   const deps = Array.isArray(s.dependsOn) ? s.dependsOn : [];

--- a/backend/lib/health/probes.js
+++ b/backend/lib/health/probes.js
@@ -1,0 +1,303 @@
+'use strict';
+
+const net = require('net');
+const dgram = require('dgram');
+const http = require('http');
+const https = require('https');
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const MAX_BODY_BYTES = 8192;
+
+function normalizeResult(ok, latencyMs, evidence, error) {
+  return {
+    ok: Boolean(ok),
+    latencyMs: latencyMs == null ? null : Math.max(0, Math.round(latencyMs)),
+    evidence: evidence || {},
+    error: error || null,
+  };
+}
+
+function resolveTimeout(opts) {
+  const v = opts && Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  return Math.max(50, Math.min(v, 30000));
+}
+
+function httpRequestOnce(scheme, host, port, path, method, timeoutMs, allowInsecure) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const lib = scheme === 'https' ? https : http;
+    const opts = {
+      host,
+      port,
+      path: path || '/',
+      method,
+      timeout: timeoutMs,
+      headers: { 'User-Agent': 'PortTracker/1.0', 'Accept': '*/*' },
+    };
+    if (scheme === 'https' && allowInsecure) opts.rejectUnauthorized = false;
+    let settled = false;
+    const req = lib.request(opts, (res) => {
+      const statusCode = res.statusCode || 0;
+      let bytes = 0;
+      const chunks = [];
+      res.on('data', (c) => {
+        bytes += c.length;
+        if (chunks.length < 4 && bytes <= MAX_BODY_BYTES) chunks.push(c);
+      });
+      res.on('end', () => {
+        if (settled) return;
+        settled = true;
+        const latency = Date.now() - started;
+        const headers = res.headers || {};
+        const body = Buffer.concat(chunks).toString('utf8').slice(0, MAX_BODY_BYTES);
+        resolve({ statusCode, latency, headers, body, bytes });
+      });
+      res.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        resolve({ error: err.message, latency: Date.now() - started });
+      });
+      res.resume();
+    });
+    req.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      resolve({ error: err.message, latency: Date.now() - started });
+    });
+    req.on('timeout', () => {
+      if (settled) return;
+      settled = true;
+      try { req.destroy(new Error('timeout')); } catch (_e) { void _e; }
+      resolve({ error: 'timeout', latency: Date.now() - started });
+    });
+    req.end();
+  });
+}
+
+async function probeHttpLike(scheme, host, port, opts) {
+  const timeoutMs = resolveTimeout(opts);
+  const path = (opts && opts.path) || '/';
+  const allowInsecure = scheme === 'https' && !(opts && opts.strictTls);
+  const started = Date.now();
+
+  const head = await httpRequestOnce(scheme, host, port, path, 'HEAD', timeoutMs, allowInsecure);
+  if (head && head.statusCode && head.statusCode < 500 && head.statusCode !== 404) {
+    return normalizeResult(true, head.latency, {
+      protocol: scheme,
+      method: 'HEAD',
+      statusCode: head.statusCode,
+      url: `${scheme}://${host}:${port}${path}`,
+    }, null);
+  }
+
+  const remaining = Math.max(50, timeoutMs - (Date.now() - started));
+  const get = await httpRequestOnce(scheme, host, port, path, 'GET', remaining, allowInsecure);
+  if (get && get.statusCode && get.statusCode < 500) {
+    return normalizeResult(true, get.latency, {
+      protocol: scheme,
+      method: 'GET',
+      statusCode: get.statusCode,
+      url: `${scheme}://${host}:${port}${path}`,
+      bytes: get.bytes,
+    }, null);
+  }
+
+  const err = (get && get.error) || (head && head.error) || 'No successful response';
+  return normalizeResult(false, Date.now() - started, {
+    protocol: scheme,
+    url: `${scheme}://${host}:${port}${path}`,
+    headStatus: head ? head.statusCode || null : null,
+    getStatus: get ? get.statusCode || null : null,
+  }, err);
+}
+
+function probeHttp(host, port, opts) {
+  return probeHttpLike('http', host, port, opts);
+}
+
+function probeHttps(host, port, opts) {
+  return probeHttpLike('https', host, port, opts);
+}
+
+function probeTcp(host, port, opts) {
+  const timeoutMs = resolveTimeout(opts);
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const socket = new net.Socket();
+    let settled = false;
+    function finish(ok, error) {
+      if (settled) return;
+      settled = true;
+      const latency = Date.now() - started;
+      try { socket.destroy(); } catch (_e) { void _e; }
+      resolve(normalizeResult(ok, latency, {
+        protocol: 'tcp',
+        host,
+        port,
+      }, error));
+    }
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish(true, null));
+    socket.once('timeout', () => finish(false, 'timeout'));
+    socket.once('error', (err) => finish(false, err && err.message ? err.message : 'error'));
+    try {
+      socket.connect({ host, port });
+    } catch (err) {
+      finish(false, err && err.message ? err.message : 'error');
+    }
+  });
+}
+
+function probeUdp(host, port, opts) {
+  const timeoutMs = resolveTimeout(opts);
+  const payload = opts && Buffer.isBuffer(opts.payload)
+    ? opts.payload
+    : Buffer.from([0x00]);
+  const isIPv6 = host && host.includes(':');
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const socket = dgram.createSocket(isIPv6 ? 'udp6' : 'udp4');
+    let settled = false;
+    let timer = null;
+
+    function finish(ok, error, extra) {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      try { socket.close(); } catch (_e) { void _e; }
+      resolve(normalizeResult(ok, Date.now() - started, Object.assign({
+        protocol: 'udp',
+        host,
+        port,
+      }, extra || {}), error));
+    }
+
+    socket.once('error', (err) => {
+      const msg = err && err.message ? err.message : 'error';
+      const code = err && err.code ? err.code : null;
+      if (code === 'ECONNREFUSED' || code === 'EHOSTUNREACH' || code === 'ENETUNREACH') {
+        finish(false, msg, { code });
+        return;
+      }
+      finish(false, msg, { code });
+    });
+
+    socket.once('message', (msg, rinfo) => {
+      finish(true, null, { responded: true, fromPort: rinfo && rinfo.port, bytes: msg.length });
+    });
+
+    try {
+      socket.send(payload, 0, payload.length, port, host, (err) => {
+        if (err) {
+          finish(false, err.message || 'send-failed', null);
+          return;
+        }
+        timer = setTimeout(() => {
+          finish(true, null, { responded: false, assumed: 'no-icmp-unreachable' });
+        }, timeoutMs);
+      });
+    } catch (err) {
+      finish(false, err && err.message ? err.message : 'send-threw', null);
+    }
+  });
+}
+
+async function probeContainerState(dockerApi, containerId, _opts) {
+  const started = Date.now();
+  if (!dockerApi || typeof dockerApi.getContainerHealth !== 'function') {
+    return normalizeResult(false, Date.now() - started, { kind: 'container-state' }, 'docker-api-unavailable');
+  }
+  if (!containerId) {
+    return normalizeResult(false, Date.now() - started, { kind: 'container-state' }, 'missing-container-id');
+  }
+  try {
+    if (typeof dockerApi._ensureConnected === 'function') {
+      await dockerApi._ensureConnected().catch(() => null);
+    }
+    const h = await dockerApi.getContainerHealth(containerId);
+    const status = (h && h.status ? String(h.status) : 'unknown').toLowerCase();
+    const health = (h && h.health ? String(h.health) : 'none').toLowerCase();
+    const running = status === 'running';
+    const healthy = running && (health === 'healthy' || health === 'none' || health === 'unknown' || health === 'starting');
+    const evidence = {
+      kind: 'container-state',
+      containerId,
+      status,
+      health,
+      startedAt: h && h.startedAt ? h.startedAt : null,
+      restartCount: h && typeof h.restartCount === 'number' ? h.restartCount : null,
+    };
+    if (!running) {
+      return normalizeResult(false, Date.now() - started, evidence, `container-${status}`);
+    }
+    if (health === 'unhealthy') {
+      return normalizeResult(false, Date.now() - started, evidence, 'healthcheck-unhealthy');
+    }
+    return normalizeResult(healthy, Date.now() - started, evidence, null);
+  } catch (err) {
+    return normalizeResult(false, Date.now() - started, { kind: 'container-state', containerId }, err && err.message ? err.message : 'inspect-failed');
+  }
+}
+
+async function probeJobCompletion(dockerApi, containerId, opts) {
+  const started = Date.now();
+  const maxAgeMs = opts && Number.isFinite(opts.maxAgeMs) ? opts.maxAgeMs : null;
+  if (!dockerApi || typeof dockerApi.inspectContainer !== 'function') {
+    return normalizeResult(false, Date.now() - started, { kind: 'job-completion' }, 'docker-api-unavailable');
+  }
+  if (!containerId) {
+    return normalizeResult(false, Date.now() - started, { kind: 'job-completion' }, 'missing-container-id');
+  }
+  try {
+    if (typeof dockerApi._ensureConnected === 'function') {
+      await dockerApi._ensureConnected().catch(() => null);
+    }
+    const inspection = await dockerApi.inspectContainer(containerId);
+    const state = inspection && inspection.State ? inspection.State : {};
+    const status = String(state.Status || 'unknown').toLowerCase();
+    const exitCode = Number.isFinite(state.ExitCode) ? state.ExitCode : null;
+    const finishedAt = state.FinishedAt || null;
+    const restartPolicy = inspection && inspection.HostConfig && inspection.HostConfig.RestartPolicy
+      ? inspection.HostConfig.RestartPolicy.Name || 'no'
+      : 'no';
+
+    const evidence = {
+      kind: 'job-completion',
+      containerId,
+      status,
+      exitCode,
+      finishedAt,
+      restartPolicy,
+    };
+
+    if (status !== 'exited') {
+      return normalizeResult(false, Date.now() - started, evidence, `not-exited-${status}`);
+    }
+    if (exitCode !== 0) {
+      return normalizeResult(false, Date.now() - started, evidence, `exit-code-${exitCode}`);
+    }
+    if (maxAgeMs != null && finishedAt) {
+      const finishedMs = Date.parse(finishedAt);
+      if (Number.isFinite(finishedMs)) {
+        const age = Date.now() - finishedMs;
+        evidence.ageMs = age;
+        if (age > maxAgeMs) {
+          return normalizeResult(false, Date.now() - started, evidence, 'stale-completion');
+        }
+      }
+    }
+    return normalizeResult(true, Date.now() - started, evidence, null);
+  } catch (err) {
+    return normalizeResult(false, Date.now() - started, { kind: 'job-completion', containerId }, err && err.message ? err.message : 'inspect-failed');
+  }
+}
+
+module.exports = {
+  probeHttp,
+  probeHttps,
+  probeTcp,
+  probeUdp,
+  probeContainerState,
+  probeJobCompletion,
+  DEFAULT_TIMEOUT_MS,
+};

--- a/backend/lib/health/probes.js
+++ b/backend/lib/health/probes.js
@@ -83,6 +83,7 @@ async function probeHttpLike(scheme, host, port, opts) {
   const head = await httpRequestOnce(scheme, host, port, path, 'HEAD', timeoutMs, allowInsecure);
   if (head && head.statusCode && head.statusCode < 500 && head.statusCode !== 404) {
     return normalizeResult(true, head.latency, {
+      kind: scheme,
       protocol: scheme,
       method: 'HEAD',
       statusCode: head.statusCode,
@@ -94,6 +95,7 @@ async function probeHttpLike(scheme, host, port, opts) {
   const get = await httpRequestOnce(scheme, host, port, path, 'GET', remaining, allowInsecure);
   if (get && get.statusCode && get.statusCode < 500) {
     return normalizeResult(true, get.latency, {
+      kind: scheme,
       protocol: scheme,
       method: 'GET',
       statusCode: get.statusCode,
@@ -104,6 +106,7 @@ async function probeHttpLike(scheme, host, port, opts) {
 
   const err = (get && get.error) || (head && head.error) || 'No successful response';
   return normalizeResult(false, Date.now() - started, {
+    kind: scheme,
     protocol: scheme,
     url: `${scheme}://${host}:${port}${path}`,
     headStatus: head ? head.statusCode || null : null,
@@ -131,6 +134,7 @@ function probeTcp(host, port, opts) {
       const latency = Date.now() - started;
       try { socket.destroy(); } catch (_e) { void _e; }
       resolve(normalizeResult(ok, latency, {
+        kind: 'tcp',
         protocol: 'tcp',
         host,
         port,
@@ -166,6 +170,7 @@ function probeUdp(host, port, opts) {
       if (timer) clearTimeout(timer);
       try { socket.close(); } catch (_e) { void _e; }
       resolve(normalizeResult(ok, Date.now() - started, Object.assign({
+        kind: 'udp',
         protocol: 'udp',
         host,
         port,

--- a/backend/lib/health/service-health.js
+++ b/backend/lib/health/service-health.js
@@ -1,0 +1,370 @@
+'use strict';
+
+const { extractSignals } = require('./signals');
+const { classify, ROLES } = require('./classify');
+const {
+  probeHttp,
+  probeHttps,
+  probeTcp,
+  probeUdp,
+  probeContainerState,
+  probeJobCompletion,
+  DEFAULT_TIMEOUT_MS,
+} = require('./probes');
+const { aggregate } = require('./aggregate');
+
+function safeLower(v) {
+  return typeof v === 'string' ? v.toLowerCase() : '';
+}
+
+function resolveProbeHost(hostIp) {
+  const h = safeLower(hostIp);
+  const override = (process.env.HOST_OVERRIDE || '').trim();
+  if (h === '' || h === '0.0.0.0' || h === '::' || h === '[::]') {
+    return override || '127.0.0.1';
+  }
+  if (h === '::1') return '::1';
+  return hostIp;
+}
+
+function pickRepresentativePort(ports) {
+  const list = Array.isArray(ports) ? ports.filter(Boolean) : [];
+  if (list.length === 0) return null;
+  const score = (p) => {
+    const host = safeLower(p.host_ip || '');
+    const isLoopback = host === '127.0.0.1' || host === '::1' || host === 'localhost';
+    const proto = safeLower(p.protocol || 'tcp');
+    let s = 0;
+    if (p.internal !== true) s += 1000;
+    if (!isLoopback) s += 100;
+    if (proto === 'tcp') s += 10;
+    const n = parseInt(p.host_port, 10);
+    if (Number.isFinite(n) && n > 0) s -= Math.min(n, 65535) / 70000;
+    return s;
+  };
+  return list.slice().sort((a, b) => score(b) - score(a))[0];
+}
+
+function onDemandKeysFromDeps(deps) {
+  const set = new Set();
+  if (!deps) return set;
+  const source = deps.onDemandPorts;
+  if (!source) return set;
+  const push = (v) => { if (typeof v === 'string' && v) set.add(v); };
+  if (source instanceof Set) source.forEach(push);
+  else if (Array.isArray(source)) source.forEach(push);
+  return set;
+}
+
+function isOnDemandPort(port, onDemandSet) {
+  if (!port || !onDemandSet || onDemandSet.size === 0) return false;
+  const cid = port.container_id || '';
+  const hp = port.host_port;
+  if (cid) {
+    if (onDemandSet.has(`${cid}:${hp}`)) return true;
+    if (onDemandSet.has(`${cid.slice(0, 12)}:${hp}`)) return true;
+  }
+  return false;
+}
+
+function groupPortsByContainer(ports) {
+  const map = new Map();
+  (ports || []).forEach((p) => {
+    if (!p) return;
+    const key = p.container_id || `${p.owner || 'unknown'}::${p.host_ip || ''}:${p.host_port || ''}`;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(p);
+  });
+  return map;
+}
+
+function buildSiblingContext(servicePorts, componentSignals, allSignalsByContainer) {
+  const siblingServices = [];
+  allSignalsByContainer.forEach((sig) => {
+    if (sig.composeService && sig.composeService !== componentSignals.composeService) {
+      if (!siblingServices.includes(sig.composeService)) siblingServices.push(sig.composeService);
+    }
+  });
+
+  let siblingDependsOnUs = false;
+  allSignalsByContainer.forEach((sig) => {
+    if (sig.composeService && componentSignals.composeService) {
+      if (Array.isArray(sig.dependsOn) && sig.dependsOn.includes(componentSignals.composeService)) {
+        siblingDependsOnUs = true;
+      }
+    }
+  });
+
+  let serviceHasHttpResponder = false;
+  (servicePorts || []).forEach((p) => {
+    if (safeLower(p.protocol || 'tcp') === 'tcp') {
+      serviceHasHttpResponder = true;
+    }
+  });
+
+  return {
+    siblingServices,
+    siblingDependsOnUs,
+    serviceHasHttpResponder,
+  };
+}
+
+function isLoopbackHost(hostIp) {
+  const h = safeLower(hostIp || '');
+  return h === '127.0.0.1' || h === '::1' || h === 'localhost';
+}
+
+async function tryLoopbackRescue(port, dockerApi, inspectionCache, timeoutMs) {
+  const containerId = port && port.container_id;
+  if (!containerId || !dockerApi || typeof dockerApi.inspectContainer !== 'function') {
+    return { applicable: false };
+  }
+  let inspection = inspectionCache.get(containerId);
+  if (inspection === undefined) {
+    try {
+      inspection = await dockerApi.inspectContainer(containerId);
+    } catch (_e) {
+      void _e;
+      inspection = null;
+    }
+    inspectionCache.set(containerId, inspection);
+  }
+  if (!inspection) return { applicable: false };
+  const networkMode = safeLower(inspection.HostConfig && inspection.HostConfig.NetworkMode);
+  if (networkMode === 'host' || networkMode === 'none') {
+    return { applicable: false, reason: 'host-network', networkMode };
+  }
+  const networks = (inspection.NetworkSettings && inspection.NetworkSettings.Networks) || {};
+  let containerIp = null;
+  for (const info of Object.values(networks)) {
+    const ip = info && info.IPAddress;
+    if (ip && ip !== '0.0.0.0') { containerIp = ip; break; }
+  }
+  if (!containerIp) return { applicable: false, reason: 'no-bridge-ip' };
+  const portsMap = (inspection.NetworkSettings && inspection.NetworkSettings.Ports) || {};
+  const proto = safeLower(port.protocol || 'tcp');
+  let containerPort = null;
+  for (const [spec, bindings] of Object.entries(portsMap)) {
+    if (!bindings) continue;
+    const [cpStr, cproto] = String(spec).split('/');
+    if (safeLower(cproto || 'tcp') !== proto) continue;
+    const matched = bindings.some((b) => {
+      const hp = parseInt(b && b.HostPort, 10);
+      return Number.isFinite(hp) && hp === parseInt(port.host_port, 10);
+    });
+    if (matched) {
+      const n = parseInt(cpStr, 10);
+      if (Number.isFinite(n)) { containerPort = n; break; }
+    }
+  }
+  if (containerPort == null) {
+    const n = parseInt(port.host_port, 10);
+    if (Number.isFinite(n)) containerPort = n;
+  }
+  if (containerPort == null) return { applicable: false, reason: 'no-container-port' };
+  const r = await probeTcp(containerIp, containerPort, { timeoutMs });
+  return { applicable: true, ok: r.ok, error: r.error || null, containerIp, containerPort };
+}
+
+async function sweepExternalPorts(groupPorts, opts) {
+  const timeoutMs = opts && Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const onDemandSet = opts && opts.onDemandSet ? opts.onDemandSet : new Set();
+  const dockerApi = opts && opts.dockerApi ? opts.dockerApi : null;
+  const inspectionCache = opts && opts.inspectionCache ? opts.inspectionCache : new Map();
+  const externals = (groupPorts || []).filter((p) => p && p.internal !== true);
+  const failures = [];
+  const suppressed = [];
+  for (const p of externals) {
+    if (isOnDemandPort(p, onDemandSet)) continue;
+    const host = resolveProbeHost(p.host_ip);
+    const port = parseInt(p.host_port, 10);
+    if (!Number.isFinite(port) || port <= 0 || port > 65535) continue;
+    const proto = safeLower(p.protocol || 'tcp');
+    if (proto !== 'tcp') continue;
+    const r = await probeTcp(host, port, { timeoutMs });
+    if (r.ok) continue;
+    if (isLoopbackHost(p.host_ip)) {
+      const rescue = await tryLoopbackRescue(p, dockerApi, inspectionCache, timeoutMs);
+      if (rescue.applicable && rescue.ok) {
+        continue;
+      }
+      if (!rescue.applicable) {
+        suppressed.push({
+          host_ip: p.host_ip || null,
+          host_port: p.host_port,
+          reason: rescue.reason || 'loopback-only-by-design',
+        });
+        continue;
+      }
+      failures.push({
+        host_ip: p.host_ip || null,
+        host_port: p.host_port,
+        error: rescue.error || r.error || 'unreachable',
+        rescue: { containerIp: rescue.containerIp, containerPort: rescue.containerPort },
+      });
+      continue;
+    }
+    const bridgeRescue = await tryLoopbackRescue(p, dockerApi, inspectionCache, timeoutMs);
+    if (bridgeRescue.applicable && bridgeRescue.ok) {
+      continue;
+    }
+    failures.push({
+      host_ip: p.host_ip || null,
+      host_port: p.host_port,
+      error: r.error || 'unreachable',
+    });
+  }
+  return { failures, suppressed };
+}
+
+async function pickAndRunProbe(signals, representative, dockerApi, opts, groupPorts) {
+  const timeoutMs = opts && Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const onDemandSet = opts && opts.onDemandSet ? opts.onDemandSet : onDemandKeysFromDeps(opts);
+  const inspectionCache = opts && opts.inspectionCache ? opts.inspectionCache : new Map();
+  const hasExternal = Array.isArray(groupPorts) && groupPorts.some((p) => p && p.internal !== true);
+
+  if (signals.hasHealthcheck && signals.containerId) {
+    const hc = await probeContainerState(dockerApi, signals.containerId, { timeoutMs });
+    if (!hc.ok) return hc;
+    if (hasExternal) {
+      const sweep = await sweepExternalPorts(groupPorts, { timeoutMs, onDemandSet, dockerApi, inspectionCache });
+      const failures = sweep.failures || [];
+      const suppressed = sweep.suppressed || [];
+      if (failures.length > 0) {
+        return {
+          ok: true,
+          severity: 'yellow',
+          latencyMs: hc.latencyMs,
+          evidence: { kind: 'partial', healthcheck: hc.evidence, failures, suppressed },
+          error: `Service is running, but ${failures.length} published port${failures.length === 1 ? " isn't" : "s aren't"} responding`,
+        };
+      }
+      if (suppressed.length > 0) {
+        return {
+          ok: hc.ok,
+          severity: hc.severity || null,
+          latencyMs: hc.latencyMs,
+          evidence: { ...hc.evidence, suppressed },
+          error: hc.error || null,
+        };
+      }
+    }
+    return hc;
+  }
+
+  if (signals.containerState === 'exited') {
+    return probeJobCompletion(dockerApi, signals.containerId, { timeoutMs });
+  }
+
+  if (!hasExternal && signals.containerId) {
+    return probeContainerState(dockerApi, signals.containerId, { timeoutMs });
+  }
+
+  const host = resolveProbeHost(representative && representative.host_ip);
+  const port = parseInt(representative && representative.host_port, 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    return {
+      ok: false,
+      latencyMs: null,
+      evidence: { kind: 'invalid-port' },
+      error: 'no-valid-host-port',
+    };
+  }
+
+  const proto = safeLower(signals.protocol || 'tcp');
+  if (proto === 'udp') {
+    return probeUdp(host, port, { timeoutMs });
+  }
+
+  const tcp = await probeTcp(host, port, { timeoutMs });
+  if (!tcp.ok) return tcp;
+
+  const https = await probeHttps(host, port, { timeoutMs });
+  if (https.ok) return https;
+  const http = await probeHttp(host, port, { timeoutMs });
+  if (http.ok) return http;
+  return tcp;
+}
+
+async function computeServiceHealth(service, deps) {
+  const dockerApi = deps && deps.dockerApi ? deps.dockerApi : null;
+  const overrides = deps && deps.overrides && typeof deps.overrides === 'object' ? deps.overrides : {};
+  const ports = Array.isArray(service && service.ports) ? service.ports : [];
+
+  if (dockerApi && typeof dockerApi._ensureConnected === 'function') {
+    await dockerApi._ensureConnected().catch(() => null);
+  }
+
+  const groups = groupPortsByContainer(ports);
+  const inspections = new Map();
+  const signalsByContainer = new Map();
+  const representativeByContainer = new Map();
+
+  for (const [key, groupPorts] of groups.entries()) {
+    const representative = pickRepresentativePort(groupPorts);
+    representativeByContainer.set(key, representative);
+    const containerId = representative && representative.container_id ? representative.container_id : null;
+    let inspection = null;
+    if (containerId && dockerApi && typeof dockerApi.inspectContainer === 'function') {
+      try {
+        inspection = await dockerApi.inspectContainer(containerId);
+      } catch (_err) {
+        inspection = null;
+      }
+      inspections.set(key, inspection);
+    }
+    const sig = extractSignals(representative, inspection, ports);
+    signalsByContainer.set(key, sig);
+  }
+
+  const entries = [];
+  for (const [key, sig] of signalsByContainer.entries()) {
+    const representative = representativeByContainer.get(key);
+    const siblingCtx = buildSiblingContext(ports, sig, signalsByContainer);
+    const overrideKey = sig.containerId ? `${service.serviceId || ''}::${sig.containerId}` : null;
+    const overrideRole = overrideKey && typeof overrides[overrideKey] === 'string' ? overrides[overrideKey] : null;
+    const classification = classify(sig, {
+      siblingServices: siblingCtx.siblingServices,
+      siblingDependsOnUs: siblingCtx.siblingDependsOnUs,
+      serviceHasHttpResponder: siblingCtx.serviceHasHttpResponder,
+      override: overrideRole,
+    });
+
+    let probe;
+    if (classification.role === ROLES.JOB_EXPECTED_EXIT) {
+      probe = { ok: true, latencyMs: null, evidence: { kind: 'job-expected-exit', containerId: sig.containerId }, error: null };
+    } else {
+      const groupPorts = groups.get(key) || [];
+      const probeOpts = Object.assign({}, deps || {}, {
+        onDemandSet: onDemandKeysFromDeps(deps),
+        inspectionCache: inspections,
+      });
+      probe = await pickAndRunProbe(sig, representative, dockerApi, probeOpts, groupPorts);
+    }
+
+    entries.push({
+      componentId: sig.containerId || key,
+      containerId: sig.containerId,
+      signals: sig,
+      classification,
+      probe,
+    });
+  }
+
+  const result = aggregate(entries);
+  return {
+    serviceId: service.serviceId || null,
+    name: service.name || null,
+    color: result.color,
+    reason: result.reason,
+    failingComponents: result.failingComponents,
+    components: result.components,
+    evidence: result.evidence,
+  };
+}
+
+module.exports = {
+  computeServiceHealth,
+  pickRepresentativePort,
+  groupPortsByContainer,
+};

--- a/backend/lib/health/service-health.js
+++ b/backend/lib/health/service-health.js
@@ -321,8 +321,7 @@ async function computeServiceHealth(service, deps) {
   for (const [key, sig] of signalsByContainer.entries()) {
     const representative = representativeByContainer.get(key);
     const siblingCtx = buildSiblingContext(ports, sig, signalsByContainer);
-    const overrideKey = sig.containerId ? `${service.serviceId || ''}::${sig.containerId}` : null;
-    const overrideRole = overrideKey && typeof overrides[overrideKey] === 'string' ? overrides[overrideKey] : null;
+    const overrideRole = sig.containerId && typeof overrides[sig.containerId] === 'string' ? overrides[sig.containerId] : null;
     const classification = classify(sig, {
       siblingServices: siblingCtx.siblingServices,
       siblingDependsOnUs: siblingCtx.siblingDependsOnUs,

--- a/backend/lib/health/signals.js
+++ b/backend/lib/health/signals.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const WEAK_SUPPORT_HINTS = ['exporter', 'metrics', 'sidecar', 'prometheus-'];
+const WEAK_PROXY_HINTS = ['proxy', 'nginx', 'traefik', 'caddy', 'haproxy', 'envoy'];
+
+function safeLower(v) {
+  return typeof v === 'string' ? v.toLowerCase() : '';
+}
+
+function toNumericPort(v) {
+  const n = typeof v === 'number' ? v : parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 && n <= 65535 ? n : null;
+}
+
+function pickProtocol(port, inspection) {
+  const direct = safeLower(port && (port.protocol || port.port_proto || port.proto));
+  if (direct === 'tcp' || direct === 'udp') return direct;
+
+  const portNum = toNumericPort(port && (port.host_port || port.container_port));
+  if (inspection && inspection.NetworkSettings && inspection.NetworkSettings.Ports && portNum != null) {
+    const map = inspection.NetworkSettings.Ports;
+    for (const key of Object.keys(map)) {
+      const parts = key.split('/');
+      if (parts.length === 2 && toNumericPort(parts[0]) === portNum) {
+        const proto = safeLower(parts[1]);
+        if (proto === 'tcp' || proto === 'udp') return proto;
+      }
+    }
+  }
+  return 'tcp';
+}
+
+function extractHealthcheck(inspection) {
+  if (!inspection || !inspection.State) {
+    return { declared: false, status: null };
+  }
+  const state = inspection.State;
+  const hasHealthBlock = !!state.Health;
+  const status = hasHealthBlock ? safeLower(state.Health.Status || '') : '';
+  const cfg = inspection.Config && inspection.Config.Healthcheck;
+  const declared = hasHealthBlock && status && status !== 'none'
+    ? true
+    : !!(cfg && Array.isArray(cfg.Test) && cfg.Test.length > 0 && cfg.Test[0] !== 'NONE');
+  return {
+    declared,
+    status: declared ? (status || 'starting') : null,
+  };
+}
+
+function extractContainerState(inspection) {
+  if (!inspection || !inspection.State) {
+    return { status: 'unknown', exitCode: null, startedAt: null, finishedAt: null };
+  }
+  const s = inspection.State;
+  return {
+    status: safeLower(s.Status || 'unknown'),
+    exitCode: Number.isFinite(s.ExitCode) ? s.ExitCode : null,
+    startedAt: s.StartedAt || null,
+    finishedAt: s.FinishedAt || null,
+  };
+}
+
+function extractRestartPolicy(inspection) {
+  if (!inspection || !inspection.HostConfig || !inspection.HostConfig.RestartPolicy) return 'no';
+  const name = inspection.HostConfig.RestartPolicy.Name;
+  return typeof name === 'string' && name.length > 0 ? name : 'no';
+}
+
+function extractDependsOn(inspection) {
+  if (!inspection || !inspection.Config || !inspection.Config.Labels) return [];
+  const labels = inspection.Config.Labels;
+  const raw = labels['com.docker.compose.depends_on'];
+  if (!raw || typeof raw !== 'string') return [];
+  return raw.split(',')
+    .map((s) => s.split(':')[0].trim())
+    .filter((s) => s.length > 0);
+}
+
+function extractComposeLabels(port, inspection) {
+  const labels = (inspection && inspection.Config && inspection.Config.Labels) || {};
+  const project = (port && port.compose_project)
+    || labels['com.docker.compose.project']
+    || null;
+  const service = (port && port.compose_service)
+    || labels['com.docker.compose.service']
+    || null;
+  return {
+    project: project || null,
+    service: service || null,
+  };
+}
+
+function imageHints(inspection) {
+  const raw = safeLower(inspection && inspection.Config && inspection.Config.Image);
+  if (!raw) return { isExporterLike: false, isProxyLike: false, raw: null };
+  return {
+    isExporterLike: WEAK_SUPPORT_HINTS.some((h) => raw.includes(h)),
+    isProxyLike: WEAK_PROXY_HINTS.some((h) => raw.includes(h)),
+    raw,
+  };
+}
+
+function bindCategory(host) {
+  const h = safeLower(host);
+  if (h === '127.0.0.1' || h === '::1' || h === 'localhost') return 'loopback';
+  if (h === '' || h === '0.0.0.0' || h === '[::]' || h === '::') return 'any';
+  return 'specific';
+}
+
+function isOnlyPublishedPort(port, servicePorts) {
+  if (!Array.isArray(servicePorts) || servicePorts.length === 0) return false;
+  const published = servicePorts.filter((p) => {
+    if (p && p.internal === true) return false;
+    const host = safeLower(p && (p.host_ip != null ? p.host_ip : ''));
+    return toNumericPort(p && p.host_port) != null && host !== '127.0.0.1' && host !== '::1' && host !== 'localhost';
+  });
+  return published.length === 1
+    && toNumericPort(published[0].host_port) === toNumericPort(port && port.host_port)
+    && safeLower(published[0].protocol || '') === safeLower(port && port.protocol || '');
+}
+
+function extractSignals(port, inspection, servicePorts) {
+  const safePort = port || {};
+  const compose = extractComposeLabels(safePort, inspection);
+  const hc = extractHealthcheck(inspection);
+  const state = extractContainerState(inspection);
+  const hints = imageHints(inspection);
+  const protocol = pickProtocol(safePort, inspection);
+  const portNum = toNumericPort(safePort.host_port || safePort.container_port);
+
+  return {
+    protocol,
+    portNumber: portNum,
+    hasHealthcheck: hc.declared,
+    healthcheckStatus: hc.status,
+    containerState: state.status,
+    exitCode: state.exitCode,
+    startedAt: state.startedAt,
+    finishedAt: state.finishedAt,
+    restartPolicy: extractRestartPolicy(inspection),
+    isOnlyPublishedPort: isOnlyPublishedPort(safePort, servicePorts),
+    boundTo: bindCategory(safePort.host_ip),
+    composeProject: compose.project,
+    composeService: compose.service,
+    dependsOn: extractDependsOn(inspection),
+    imageHints: hints,
+    owner: safePort.owner || null,
+    source: safePort.source || null,
+    containerId: safePort.container_id || (inspection && inspection.Id) || null,
+  };
+}
+
+module.exports = {
+  extractSignals,
+  WEAK_SUPPORT_HINTS,
+  WEAK_PROXY_HINTS,
+};

--- a/backend/lib/health/signals.js
+++ b/backend/lib/health/signals.js
@@ -38,12 +38,13 @@ function extractHealthcheck(inspection) {
   const hasHealthBlock = !!state.Health;
   const status = hasHealthBlock ? safeLower(state.Health.Status || '') : '';
   const cfg = inspection.Config && inspection.Config.Healthcheck;
-  const declared = hasHealthBlock && status && status !== 'none'
+  const hasRealHealth = hasHealthBlock && status && status !== 'none';
+  const declared = hasRealHealth
     ? true
     : !!(cfg && Array.isArray(cfg.Test) && cfg.Test.length > 0 && cfg.Test[0] !== 'NONE');
   return {
     declared,
-    status: declared ? (status || 'starting') : null,
+    status: hasRealHealth ? status : null,
   };
 }
 

--- a/backend/lib/overrides.js
+++ b/backend/lib/overrides.js
@@ -1,0 +1,88 @@
+const db = require('../db');
+
+const VALID_ROLES = new Set(['core_runtime', 'core_access', 'support', 'job_expected_exit', 'unknown']);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS component_overrides (
+    server_id TEXT NOT NULL,
+    service_id TEXT NOT NULL,
+    component_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (server_id, component_id)
+  );
+`);
+
+const stmtUpsert = db.prepare(`
+  INSERT INTO component_overrides (server_id, service_id, component_id, role, updated_at)
+  VALUES (?, ?, ?, ?, ?)
+  ON CONFLICT(server_id, component_id) DO UPDATE SET
+    service_id = excluded.service_id,
+    role = excluded.role,
+    updated_at = excluded.updated_at
+`);
+
+const stmtDeleteOne = db.prepare(`
+  DELETE FROM component_overrides WHERE server_id = ? AND component_id = ?
+`);
+
+const stmtDeleteForService = db.prepare(`
+  DELETE FROM component_overrides WHERE server_id = ? AND service_id = ?
+`);
+
+const stmtDeleteForServer = db.prepare(`
+  DELETE FROM component_overrides WHERE server_id = ?
+`);
+
+const stmtListForServer = db.prepare(`
+  SELECT service_id, component_id, role, updated_at FROM component_overrides WHERE server_id = ?
+`);
+
+function isValidRole(role) {
+  return typeof role === 'string' && VALID_ROLES.has(role);
+}
+
+function setOverride(serverId, serviceId, componentId, role) {
+  if (!serverId || !serviceId || !componentId || !isValidRole(role)) return false;
+  stmtUpsert.run(String(serverId), String(serviceId), String(componentId), role, Date.now());
+  return true;
+}
+
+function clearOverride(serverId, componentId) {
+  if (!serverId || !componentId) return 0;
+  return stmtDeleteOne.run(String(serverId), String(componentId)).changes;
+}
+
+function clearAllForService(serverId, serviceId) {
+  if (!serverId || !serviceId) return 0;
+  return stmtDeleteForService.run(String(serverId), String(serviceId)).changes;
+}
+
+function clearAllForServer(serverId) {
+  if (!serverId) return 0;
+  return stmtDeleteForServer.run(String(serverId)).changes;
+}
+
+function getOverridesForServer(serverId) {
+  if (!serverId) return {};
+  const rows = stmtListForServer.all(String(serverId));
+  const out = {};
+  rows.forEach((r) => { out[r.component_id] = r.role; });
+  return out;
+}
+
+function listOverridesForServer(serverId) {
+  if (!serverId) return [];
+  return stmtListForServer.all(String(serverId));
+}
+
+module.exports = {
+  VALID_ROLES,
+  isValidRole,
+  setOverride,
+  clearOverride,
+  clearAllForService,
+  clearAllForServer,
+  getOverridesForServer,
+  listOverridesForServer,
+};

--- a/backend/routes/services.js
+++ b/backend/routes/services.js
@@ -1,0 +1,54 @@
+const { computeServiceHealth } = require('../lib/health/service-health');
+
+function groupPortsByService(ports) {
+  const groups = new Map();
+  (ports || []).forEach((p) => {
+    if (!p || p.source === 'system' || !p.container_id) return;
+    const project = p.compose_project || '__noproject__';
+    const service = p.compose_service || (p.owner || 'unknown');
+    const key = `${project}::${service}`;
+    if (!groups.has(key)) {
+      groups.set(key, { serviceId: key, name: service, project: p.compose_project || null, ports: [] });
+    }
+    groups.get(key).ports.push(p);
+  });
+  return groups;
+}
+
+function createServicesHandler({ getLocalPortsUsingCollectors, dockerApi, logger, baseDebug }) {
+  return async function servicesHandler(req, res) {
+    if (process.env.FEAT_001_ENABLED !== 'true') {
+      return res.status(404).json({ error: 'feature-disabled' });
+    }
+    const debug = req.query.debug === "true";
+    const hasDebugQuery = Object.prototype.hasOwnProperty.call(req.query, 'debug');
+    if (hasDebugQuery) logger.setDebugEnabled(debug);
+    try {
+      const localPorts = await getLocalPortsUsingCollectors({ debug });
+      const groups = groupPortsByService(localPorts);
+      const services = [];
+      for (const svc of groups.values()) {
+        try {
+          const result = await computeServiceHealth(svc, { dockerApi, overrides: {} });
+          services.push(Object.assign({ project: svc.project }, result));
+        } catch (err) {
+          logger.error(`computeServiceHealth failed for ${svc.serviceId}:`, err.message);
+          services.push({
+            serviceId: svc.serviceId, name: svc.name, project: svc.project,
+            color: 'gray', reason: `error: ${err.message}`,
+            failingComponents: [], components: [], evidence: [],
+          });
+        }
+      }
+      res.json({ services });
+    } catch (error) {
+      logger.error("Error in GET /api/services:", error.message);
+      logger.debug("Stack trace:", error.stack || "");
+      res.status(500).json({ error: 'failed to compute services', details: error.message });
+    } finally {
+      if (hasDebugQuery) logger.setDebugEnabled(baseDebug);
+    }
+  };
+}
+
+module.exports = { createServicesHandler };

--- a/backend/routes/services.js
+++ b/backend/routes/services.js
@@ -17,9 +17,6 @@ function groupPortsByService(ports) {
 
 function createServicesHandler({ getLocalPortsUsingCollectors, dockerApi, logger, baseDebug }) {
   return async function servicesHandler(req, res) {
-    if (process.env.FEAT_001_ENABLED !== 'true') {
-      return res.status(404).json({ error: 'feature-disabled' });
-    }
     const debug = req.query.debug === "true";
     const hasDebugQuery = Object.prototype.hasOwnProperty.call(req.query, 'debug');
     if (hasDebugQuery) logger.setDebugEnabled(debug);

--- a/backend/routes/services.js
+++ b/backend/routes/services.js
@@ -1,4 +1,7 @@
 const { computeServiceHealth } = require('../lib/health/service-health');
+const overridesDao = require('../lib/overrides');
+
+const LOCAL_SERVER_ID = 'local';
 
 function groupPortsByService(ports) {
   const groups = new Map();
@@ -23,10 +26,11 @@ function createServicesHandler({ getLocalPortsUsingCollectors, dockerApi, logger
     try {
       const localPorts = await getLocalPortsUsingCollectors({ debug });
       const groups = groupPortsByService(localPorts);
+      const overrides = overridesDao.getOverridesForServer(LOCAL_SERVER_ID);
       const services = [];
       for (const svc of groups.values()) {
         try {
-          const result = await computeServiceHealth(svc, { dockerApi, overrides: {} });
+          const result = await computeServiceHealth(svc, { dockerApi, overrides });
           services.push(Object.assign({ project: svc.project }, result));
         } catch (err) {
           logger.error(`computeServiceHealth failed for ${svc.serviceId}:`, err.message);
@@ -37,7 +41,7 @@ function createServicesHandler({ getLocalPortsUsingCollectors, dockerApi, logger
           });
         }
       }
-      res.json({ services });
+      res.json({ services, overrides });
     } catch (error) {
       logger.error("Error in GET /api/services:", error.message);
       logger.debug("Stack trace:", error.stack || "");
@@ -48,4 +52,84 @@ function createServicesHandler({ getLocalPortsUsingCollectors, dockerApi, logger
   };
 }
 
-module.exports = { createServicesHandler };
+function createGetOverridesHandler({ logger }) {
+  return function getOverridesHandler(req, res) {
+    try {
+      const overrides = overridesDao.getOverridesForServer(LOCAL_SERVER_ID);
+      res.json({ overrides });
+    } catch (error) {
+      logger.error("Error in GET /api/overrides:", error.message);
+      res.status(500).json({ error: 'failed to read overrides', details: error.message });
+    }
+  };
+}
+
+function createPutOverrideHandler({ logger }) {
+  return function putOverrideHandler(req, res) {
+    const { serviceId, componentId } = req.params;
+    const role = req.body && req.body.role;
+    if (!serviceId || !componentId) {
+      return res.status(400).json({ error: 'serviceId and componentId are required' });
+    }
+    if (!overridesDao.isValidRole(role)) {
+      return res.status(400).json({ error: 'invalid role', validRoles: Array.from(overridesDao.VALID_ROLES) });
+    }
+    try {
+      const ok = overridesDao.setOverride(LOCAL_SERVER_ID, serviceId, componentId, role);
+      if (!ok) return res.status(400).json({ error: 'invalid input' });
+      res.json({ ok: true, serviceId, componentId, role });
+    } catch (error) {
+      logger.error("Error in PUT override:", error.message);
+      res.status(500).json({ error: 'failed to write override', details: error.message });
+    }
+  };
+}
+
+function createDeleteOverrideHandler({ logger }) {
+  return function deleteOverrideHandler(req, res) {
+    const { componentId } = req.params;
+    if (!componentId) return res.status(400).json({ error: 'componentId is required' });
+    try {
+      const changes = overridesDao.clearOverride(LOCAL_SERVER_ID, componentId);
+      res.json({ ok: true, removed: changes });
+    } catch (error) {
+      logger.error("Error in DELETE override:", error.message);
+      res.status(500).json({ error: 'failed to clear override', details: error.message });
+    }
+  };
+}
+
+function createDeleteServiceOverridesHandler({ logger }) {
+  return function deleteServiceOverridesHandler(req, res) {
+    const { serviceId } = req.params;
+    if (!serviceId) return res.status(400).json({ error: 'serviceId is required' });
+    try {
+      const changes = overridesDao.clearAllForService(LOCAL_SERVER_ID, serviceId);
+      res.json({ ok: true, serviceId, removed: changes });
+    } catch (error) {
+      logger.error("Error in DELETE service overrides:", error.message);
+      res.status(500).json({ error: 'failed to clear service overrides', details: error.message });
+    }
+  };
+}
+
+function createDeleteAllOverridesHandler({ logger }) {
+  return function deleteAllOverridesHandler(req, res) {
+    try {
+      const changes = overridesDao.clearAllForServer(LOCAL_SERVER_ID);
+      res.json({ ok: true, removed: changes });
+    } catch (error) {
+      logger.error("Error in DELETE all overrides:", error.message);
+      res.status(500).json({ error: 'failed to clear overrides', details: error.message });
+    }
+  };
+}
+
+module.exports = {
+  createServicesHandler,
+  createGetOverridesHandler,
+  createPutOverrideHandler,
+  createDeleteOverrideHandler,
+  createDeleteServiceOverridesHandler,
+  createDeleteAllOverridesHandler,
+};

--- a/eslint.strict.config.cjs
+++ b/eslint.strict.config.cjs
@@ -1,0 +1,14 @@
+const baseConfigs = require('./eslint.config.cjs');
+
+const overrides = {
+  rules: {
+    'max-lines-per-function': ['error', { max: 100, skipBlankLines: true, skipComments: false, IIFEs: false }],
+    'no-warning-comments': ['error', { terms: ['todo', 'fixme', 'xxx', 'hack'], location: 'anywhere' }],
+    'logs/no-line-comments': 'error',
+  },
+};
+
+module.exports = baseConfigs.map((cfg) => {
+  if (!cfg || !cfg.rules) return cfg;
+  return { ...cfg, rules: { ...cfg.rules, ...overrides.rules } };
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,11 +39,12 @@ import { generatePortKey } from "./lib/utils/portUtils";
 import { formatUptime } from "@/lib/utils";
 import { useAuth } from "./contexts/AuthContext";
 import { buildAutoRefreshMessages } from "@/lib/autoRefreshMessages";
+import { ServiceHealthProvider } from "@/hooks/useServiceHealth";
+import { OverridesProvider } from "@/hooks/useOverrides";
 
 const keyOf = (srvId, p) => generatePortKey(srvId, p);
 
 const logger = new Logger('App');
-
 
 export default function App() {
   const auth = useAuth();
@@ -110,7 +111,6 @@ export default function App() {
   }, []);
 
   const { hackerMode, konamiHint, disableHackerMode } = useKonamiHackerMode({ pushHealthToast });
-
 
   const [actionFeedback, setActionFeedback] = useState({
     copy: null,
@@ -666,6 +666,17 @@ export default function App() {
     []
   );
 
+  const whatsNewModalProps = getWhatsNewModalProps();
+
+  const sidebarLayout = useSidebarLayout({
+    pushHealthToast,
+    isWhatsNewOpen: whatsNewModalProps.isOpen,
+    loading,
+    groupCount: groups.length,
+    logger,
+  });
+  const { stampRefreshed, onOpenAddServer: handleOpenAddServer } = sidebarLayout;
+
   const fetchAll = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -930,17 +941,6 @@ export default function App() {
   }, [selectedServer, deepLinkContainer]);
 
   const searchInputRef = useRef(null);
-
-  const whatsNewModalProps = getWhatsNewModalProps();
-
-  const sidebarLayout = useSidebarLayout({
-    pushHealthToast,
-    isWhatsNewOpen: whatsNewModalProps.isOpen,
-    loading,
-    groupCount: groups.length,
-    logger,
-  });
-  const { stampRefreshed, onOpenAddServer: handleOpenAddServer } = sidebarLayout;
 
   useKeyboardShortcuts({
     onFocusSearch: () => searchInputRef.current?.focus(),
@@ -1606,7 +1606,7 @@ export default function App() {
               type: serverData.type || "peer",
               unreachable: serverData.unreachable || false,
               platform_type: serverData.platform_type || "unknown",
-              apiKey: serverData.apiKey || null,  // Always include for new servers
+              apiKey: serverData.apiKey || null,
             }),
           });
 
@@ -1873,20 +1873,17 @@ export default function App() {
         onRename={openRenameModal}
         onCopy={(p, portProtocol) => {
           let hostForCopy;
-          if (server.id === "local" &&
-              (p.host_ip === "0.0.0.0" ||
-               p.host_ip === "127.0.0.1" ||
-               p.host_ip === "[::]" ||
-               p.host_ip === "[::1]")) {
+          if (p.host_ip === "127.0.0.1" || p.host_ip === "[::1]") {
+            hostForCopy = p.host_ip === "[::1]" ? "[::1]" : "127.0.0.1";
+          }
+          else if (server.id === "local" &&
+              (p.host_ip === "0.0.0.0" || p.host_ip === "[::]")) {
             hostForCopy = hostOverride || window.location.hostname;
           }
           else if (
             server.id !== "local" &&
             server.url &&
-            (p.host_ip === "0.0.0.0" ||
-             p.host_ip === "127.0.0.1" ||
-             p.host_ip === "[::]" ||
-             p.host_ip === "[::1]")
+            (p.host_ip === "0.0.0.0" || p.host_ip === "[::]")
           ) {
             try {
               hostForCopy = new URL(server.url).hostname;
@@ -1985,6 +1982,8 @@ export default function App() {
 
   return (
     <TooltipProvider>
+      <OverridesProvider>
+      <ServiceHealthProvider>
       {konamiHint && (
         <div className="fixed top-20 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg shadow-lg border backdrop-blur-sm pointer-events-none animate-in fade-in-0 slide-in-from-top-2 duration-200 bg-white/95 dark:bg-slate-800/95 border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-100">
           <div className="flex items-center gap-2">
@@ -2272,6 +2271,8 @@ export default function App() {
         })()}
         loading={false}
       />
+      </ServiceHealthProvider>
+      </OverridesProvider>
     </TooltipProvider>
   );
 
@@ -2307,6 +2308,4 @@ export default function App() {
     }
   }
 }
-
-
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,9 +12,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { AppHeader } from "./components/layout/AppHeader";
 import { ServerSection } from "./components/server/ServerSection";
-import { Sidebar } from "./components/layout/Sidebar";
+import { AppSidebarLayout } from "./components/layout/AppSidebarLayout";
 import { Label } from "@/components/ui/label";
-import { DashboardLayout } from "./components/layout/DashboardLayout";
 import { MultipleServerSkeleton } from "./components/server/MultipleServerSkeleton";
 import { WhatsNewModal } from "./components/ui/WhatsNewModal";
 import { ServiceRenameModal } from "./components/server/ServiceRenameModal";
@@ -29,6 +28,9 @@ import { ChangePasswordPage } from "./components/auth/ChangePasswordPage";
 import { BarChart3 } from "lucide-react";
 import Logger from "./lib/logger";
 import { useWhatsNew } from "./lib/hooks/useWhatsNew";
+import { useKeyboardShortcuts } from "./lib/hooks/useKeyboardShortcuts";
+import { useSidebarLayout } from "./lib/hooks/useSidebarLayout";
+import { useKonamiHackerMode } from "./lib/hooks/useKonamiHackerMode";
 import { saveCustomServiceName, deleteCustomServiceName, getCustomServiceNames, batchCustomServiceNames } from "./lib/api/customServiceNames";
 import { batchNotes, saveNote } from "./lib/api/notes";
 import { getAutoxposeStatus, connectAutoxpose, disconnectAutoxpose, setAutoxposeDisplayMode, setAutoxposeUrlStyle, getAutoxposeServices, getAutoxposeDomain } from "./lib/api/autoxpose";
@@ -41,21 +43,6 @@ import { buildAutoRefreshMessages } from "@/lib/autoRefreshMessages";
 const keyOf = (srvId, p) => generatePortKey(srvId, p);
 
 const logger = new Logger('App');
-
-const KONAMI_SEQUENCE = [
-  "ArrowUp",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowLeft",
-  "ArrowRight",
-  "b",
-  "a"
-];
-
-const KONAMI_HINTS = ["↑", "Course input detected…", "gg, keyboard pilot."];
 
 
 export default function App() {
@@ -105,34 +92,8 @@ export default function App() {
   });
   const [batchLoading, setBatchLoading] = useState(false);
   const [renameLoading, setRenameLoading] = useState(false);
-  const [hackerMode, setHackerMode] = useState(() => {
-    try {
-      return localStorage.getItem("portracker_hacker_mode") === "true";
-    } catch {
-      return false;
-    }
-  });
-  const [konamiHint, setKonamiHint] = useState(null);
-  const konamiProgressRef = useRef(0);
-  const konamiHintStageRef = useRef(0);
-  const konamiHintTimeoutRef = useRef(null);
   const [healthToast, setHealthToast] = useState(null);
   const healthToastTimeoutRef = useRef(null);
-
-  const showKonamiHint = useCallback((stage) => {
-    const index = Math.min(stage, KONAMI_HINTS.length - 1);
-    setKonamiHint(KONAMI_HINTS[index]);
-    if (konamiHintTimeoutRef.current) {
-      clearTimeout(konamiHintTimeoutRef.current);
-    }
-    konamiHintTimeoutRef.current = setTimeout(() => setKonamiHint(null), 1200);
-  }, []);
-
-  useEffect(() => () => {
-    if (konamiHintTimeoutRef.current) {
-      clearTimeout(konamiHintTimeoutRef.current);
-    }
-  }, []);
 
   useEffect(() => () => {
     if (healthToastTimeoutRef.current) {
@@ -148,42 +109,8 @@ export default function App() {
     healthToastTimeoutRef.current = setTimeout(() => setHealthToast(null), 4000);
   }, []);
 
-  const toggleHackerMode = useCallback(() => {
-    setHackerMode(prev => {
-      const next = !prev;
-      pushHealthToast({
-        type: "info",
-        message: next
-          ? "Hacker mode activated. Use Ctrl+Shift+H to toggle."
-          : "Hacker mode disabled."
-      });
-      return next;
-    });
-    konamiHintStageRef.current = 0;
-    konamiProgressRef.current = 0;
-  }, [pushHealthToast]);
+  const { hackerMode, konamiHint, disableHackerMode } = useKonamiHackerMode({ pushHealthToast });
 
-  const disableHackerMode = useCallback(() => {
-    setHackerMode(prev => {
-      if (!prev) return prev;
-      pushHealthToast({
-        type: "info",
-        message: "Hacker mode disabled."
-      });
-      return false;
-    });
-    konamiHintStageRef.current = 0;
-    konamiProgressRef.current = 0;
-  }, [pushHealthToast]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem("portracker_hacker_mode", hackerMode ? "true" : "false");
-    } catch { void 0; }
-    if (typeof document !== "undefined") {
-      document.body.classList.toggle("hacker-mode", hackerMode);
-    }
-  }, [hackerMode]);
 
   const [actionFeedback, setActionFeedback] = useState({
     copy: null,
@@ -894,6 +821,7 @@ export default function App() {
       );
 
       setGroups(enrichedServers);
+      stampRefreshed(enrichedServers);
       setTimeout(() => setLoading(false), 300);
     } catch (error) {
       logger.error("Error in fetchAll:", error);
@@ -906,6 +834,7 @@ export default function App() {
         if (fallbackResponse.ok) {
           const legacyData = await fallbackResponse.json();
           setGroups(legacyData);
+          stampRefreshed(legacyData);
           setTimeout(() => setLoading(false), 300);
           return;
         }
@@ -916,7 +845,7 @@ export default function App() {
       setError(error.toString());
       setLoading(false);
     }
-  }, [transformCollectorData, includeUdp, disableCache]);
+  }, [transformCollectorData, includeUdp, disableCache, stampRefreshed]);
 
   const handleLogoClick = useCallback(() => {
     fetchAll();
@@ -1000,42 +929,28 @@ export default function App() {
   } catch { void 0; }
   }, [selectedServer, deepLinkContainer]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handleKeyDown = (event) => {
-      if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === "h") {
-        event.preventDefault();
-        toggleHackerMode();
-        return;
-      }
+  const searchInputRef = useRef(null);
 
-      if (event.key === "ArrowUp" && konamiProgressRef.current === 0) {
-        const stage = konamiHintStageRef.current;
-        if (stage < KONAMI_HINTS.length) {
-          showKonamiHint(stage);
-          konamiHintStageRef.current = stage + 1;
-        }
-      }
+  const whatsNewModalProps = getWhatsNewModalProps();
 
-      const normalized = event.key.length === 1 ? event.key.toLowerCase() : event.key;
-      const expected = KONAMI_SEQUENCE[konamiProgressRef.current];
+  const sidebarLayout = useSidebarLayout({
+    pushHealthToast,
+    isWhatsNewOpen: whatsNewModalProps.isOpen,
+    loading,
+    groupCount: groups.length,
+    logger,
+  });
+  const { stampRefreshed, onOpenAddServer: handleOpenAddServer } = sidebarLayout;
 
-      if (normalized === expected) {
-        konamiProgressRef.current += 1;
-        if (konamiProgressRef.current === KONAMI_SEQUENCE.length) {
-          konamiProgressRef.current = 0;
-          toggleHackerMode();
-          return;
-        }
-        return;
-      }
-
-      konamiProgressRef.current = normalized === KONAMI_SEQUENCE[0] ? 1 : 0;
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showKonamiHint, toggleHackerMode]);
+  useKeyboardShortcuts({
+    onFocusSearch: () => searchInputRef.current?.focus(),
+    onClearSearch: () => { setSearchTerm(""); },
+    onToggleSidebar: sidebarLayout.onCollapseToggle,
+    onSelectServerByIndex: (index) => {
+      if (groups[index]) handleSelectServer(groups[index].id);
+    },
+    onRefresh: fetchAll,
+  });
 
   const handleContainerOpen = useCallback((serverId, containerId) => {
     setDeepLinkContainer(containerId);
@@ -2132,21 +2047,20 @@ export default function App() {
           onOpenApiKey={() => setApiKeyModalOpen(true)}
           refreshInterval={refreshInterval}
           autoxposeStatus={autoxposeStatus}
+          searchInputRef={searchInputRef}
         />
-        <DashboardLayout
+        <AppSidebarLayout
           isSidebarOpen={isSidebarOpen}
           onCloseSidebar={() => setSidebarOpen(false)}
-          sidebar={
-            <Sidebar
-              servers={groups}
-              selectedId={selectedServer}
-              onSelect={handleSelectServer}
-              onAdd={addServer}
-              onDelete={deleteServer}
-              loading={loading}
-              hostOverride={hostOverride}
-            />
-          }
+          servers={groups}
+          selectedId={selectedServer}
+          onSelect={handleSelectServer}
+          addServer={addServer}
+          deleteServer={deleteServer}
+          loading={loading}
+          hostOverride={hostOverride}
+          sidebarLayout={sidebarLayout}
+          onOpenAddServer={handleOpenAddServer}
         >
           <main className="flex-1 overflow-auto">
             <div className="p-6">
@@ -2194,7 +2108,7 @@ export default function App() {
               )}
             </div>
           </main>
-        </DashboardLayout>
+        </AppSidebarLayout>
       </div>
 
       <Dialog open={noteModalOpen} onOpenChange={setNoteModalOpen}>
@@ -2227,7 +2141,7 @@ export default function App() {
       </Dialog>
 
       <WhatsNewModal
-        {...getWhatsNewModalProps()}
+        {...whatsNewModalProps}
         onOpenSettings={() => setSettingsModalOpen(true)}
       />
 

--- a/frontend/src/components/layout/AppHeader.jsx
+++ b/frontend/src/components/layout/AppHeader.jsx
@@ -47,10 +47,16 @@ export function AppHeader({
   onOpenApiKey,
   refreshInterval = 30000,
   autoxposeStatus = null,
+  searchInputRef,
 }) {
   const auth = useAuth();
   const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
   const [searching, setSearching] = useState(false);
+  const isMac = useMemo(
+    () => typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform),
+    []
+  );
+  const searchShortcutLabel = isMac ? "⌘K" : "Ctrl+K";
 
   const filterButtons = useMemo(
     () => [
@@ -118,7 +124,7 @@ export function AppHeader({
   const getInputPadding = () => {
     const hasClear = !!localSearchTerm;
     if (hasClear) return "pr-12";
-    return "pr-10";
+    return "pr-24 sm:pr-28";
   };
 
   const logoLongPressHandlers = useLongPress(
@@ -164,6 +170,7 @@ export function AppHeader({
               {searchIcon}
             </div>
             <Input
+              ref={searchInputRef}
               type="text"
               placeholder="Search ports, processes..."
               className={`pl-10 ${getInputPadding()} w-full max-w-[36rem] sm:max-w-[28rem] md:max-w-[32rem] lg:max-w-[40rem] border-gray-300 dark:border-gray-700 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent`}
@@ -172,6 +179,16 @@ export function AppHeader({
             />
 
             <div className="absolute inset-y-0 right-0 flex items-center pr-3 space-x-2">
+              {!localSearchTerm && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="hidden sm:inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400">
+                      {searchShortcutLabel}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Focus search • {isMac ? "Cmd+K" : "Ctrl+K"}</TooltipContent>
+                </Tooltip>
+              )}
               {localSearchTerm && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -185,7 +202,7 @@ export function AppHeader({
                       <X className="h-4 w-4" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Clear search</TooltipContent>
+                  <TooltipContent>Clear search • Esc</TooltipContent>
                 </Tooltip>
               )}
             </div>
@@ -276,7 +293,7 @@ export function AppHeader({
                 {refreshIcon}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{loading ? "Refreshing..." : "Refresh all data"}</TooltipContent>
+            <TooltipContent>{loading ? "Refreshing..." : `Refresh all data • ${isMac ? "Cmd+R" : "Ctrl+R"}`}</TooltipContent>
           </Tooltip>
 
           {onAutoRefreshToggle && (
@@ -316,7 +333,7 @@ export function AppHeader({
                 >
                   <Sparkles className="h-5 w-5" />
                   {hasNewFeatures && (
-                    <span className="absolute " />
+                    <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-indigo-500 ring-2 ring-white dark:ring-slate-900" />
                   )}
                 </Button>
               </TooltipTrigger>

--- a/frontend/src/components/layout/AppSidebarLayout.jsx
+++ b/frontend/src/components/layout/AppSidebarLayout.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { DashboardLayout } from "./DashboardLayout";
+import { Sidebar } from "./Sidebar";
+import { CollapsedSidebar } from "./CollapsedSidebar";
+
+const SIDEBAR_SHORTCUT_LABEL = "⌘B / Ctrl+B";
+const SEARCH_SHORTCUT_LABEL = "⌘K / Ctrl+K";
+
+export function AppSidebarLayout({
+  isSidebarOpen,
+  onCloseSidebar,
+  servers,
+  selectedId,
+  onSelect,
+  addServer,
+  deleteServer,
+  loading,
+  hostOverride,
+  sidebarLayout,
+  onOpenAddServer,
+  children,
+}) {
+  return (
+    <DashboardLayout
+      isSidebarOpen={isSidebarOpen}
+      onCloseSidebar={onCloseSidebar}
+      isSidebarCollapsed={sidebarLayout.isCollapsed}
+      onToggleSidebarCollapsed={sidebarLayout.onCollapseToggle}
+      sidebarWidth={sidebarLayout.width}
+      onSidebarWidthChange={sidebarLayout.onWidthChange}
+      sidebarShortcutLabel={SIDEBAR_SHORTCUT_LABEL}
+      searchShortcutLabel={SEARCH_SHORTCUT_LABEL}
+      showSidebarDiscovery={sidebarLayout.discoveryVisible}
+      onDismissSidebarDiscovery={sidebarLayout.onDiscoveryDismiss}
+      onTrySidebarDiscovery={sidebarLayout.onDiscoveryTry}
+      onSidebarMaxedOut={sidebarLayout.onSidebarMaxedOut}
+      sidebar={
+        <Sidebar
+          servers={servers}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onAdd={addServer}
+          onDelete={deleteServer}
+          loading={loading}
+          hostOverride={hostOverride}
+          lastRefreshedAt={sidebarLayout.lastRefreshedAt}
+          requestedMode={sidebarLayout.requestedMode}
+          onRequestedModeHandled={sidebarLayout.onRequestedModeHandled}
+        />
+      }
+      collapsedSidebar={
+        <CollapsedSidebar
+          servers={servers}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onAdd={onOpenAddServer}
+        />
+      }
+    >
+      {children}
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/components/layout/CollapsedSidebar.jsx
+++ b/frontend/src/components/layout/CollapsedSidebar.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Plus, BarChart3 } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+
+function ServerHealthDot({ server }) {
+  const containerCount = server.systemInfo?.containers_running || 0;
+  const portCount = server.data?.length || 0;
+  const isOnline = server.ok !== false;
+
+  if (!isOnline) {
+    return <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-red-500 ring-1 ring-white dark:ring-slate-900" />;
+  }
+  if (containerCount > 0 || portCount > 0) {
+    return <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-green-500 ring-1 ring-white dark:ring-slate-900" />;
+  }
+  return <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-gray-400 ring-1 ring-white dark:ring-slate-900" />;
+}
+
+export function CollapsedSidebar({
+  servers,
+  selectedId,
+  onSelect,
+  onAdd,
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="flex h-full flex-col overflow-hidden bg-white dark:bg-slate-900">
+        <div className="flex-shrink-0 px-3 pb-4 pt-5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="mx-auto flex h-11 w-11 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+                onClick={() => onSelect(selectedId || servers[0]?.id)}
+                aria-label="Open dashboard"
+              >
+                <BarChart3 className="h-5 w-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">All servers</TooltipContent>
+          </Tooltip>
+
+          <div className="mx-auto mt-4 h-px w-10 bg-slate-200 dark:bg-slate-700" />
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-3 pb-3 pt-1">
+          <div className="space-y-3">
+          {servers.map((server) => {
+            const name = server.label || server.server || "Server";
+            const initials = name.slice(0, 2).toUpperCase();
+            const isSelected = selectedId === server.id;
+            return (
+              <Tooltip key={server.id}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => onSelect(server.id)}
+                    className={`relative mx-auto flex h-11 w-11 items-center justify-center rounded-2xl text-xs font-bold transition-all duration-200 ${
+                      isSelected
+                        ? "bg-blue-100 text-blue-700 ring-2 ring-blue-500 dark:bg-blue-900/40 dark:text-blue-300"
+                        : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700"
+                    }`}
+                  >
+                    {initials}
+                    <ServerHealthDot server={server} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <div>
+                    <div className="font-medium">{name}</div>
+                    <div className="text-xs text-slate-400">{server.data?.length || 0} ports</div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+          </div>
+        </div>
+
+        <div className="flex-shrink-0 px-3 pb-5 pt-3">
+          <div className="mx-auto mb-3 h-px w-10 bg-slate-200 dark:bg-slate-700" />
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => onAdd()}
+                className="mx-auto flex h-11 w-11 items-center justify-center rounded-2xl border-2 border-dashed border-slate-300 text-slate-400 transition-colors hover:border-slate-400 hover:text-slate-500 dark:border-slate-700 dark:text-slate-500 dark:hover:border-slate-600 dark:hover:text-slate-400"
+                aria-label="Add server"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Add server</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/layout/DashboardLayout.jsx
+++ b/frontend/src/components/layout/DashboardLayout.jsx
@@ -1,9 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PanelLeftClose, PanelLeft, GripVertical } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SidebarDiscoveryNudge } from "./SidebarDiscoveryNudge";
+
+const MIN_SIDEBAR_WIDTH = 320;
+const MAX_SIDEBAR_WIDTH = 480;
+const COLLAPSED_SIDEBAR_WIDTH = 84;
+const DEFAULT_SIDEBAR_WIDTH = 360;
+const MAX_HIT_TRIGGER = 3;
+
 export function DashboardLayout({
   sidebar,
+  collapsedSidebar,
   children,
   isSidebarOpen,
   onCloseSidebar,
+  isSidebarCollapsed,
+  onToggleSidebarCollapsed,
+  sidebarWidth = 360,
+  onSidebarWidthChange,
+  sidebarShortcutLabel = "Cmd/Ctrl+B",
+  searchShortcutLabel = "Cmd/Ctrl+K",
+  showSidebarDiscovery = false,
+  onDismissSidebarDiscovery,
+  onTrySidebarDiscovery,
+  onSidebarMaxedOut,
 }) {
+  const [isResizing, setIsResizing] = useState(false);
+  const maxHitCountRef = useRef(0);
+  const latestWidthRef = useRef(sidebarWidth);
+  const reachedMaxDuringDragRef = useRef(false);
+
+  const clampedSidebarWidth = useMemo(
+    () => Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, sidebarWidth || 360)),
+    [sidebarWidth]
+  );
+
+  useEffect(() => {
+    latestWidthRef.current = clampedSidebarWidth;
+  }, [clampedSidebarWidth]);
+
+  useEffect(() => {
+    if (!isResizing) {
+      return undefined;
+    }
+
+    reachedMaxDuringDragRef.current = false;
+
+    const handlePointerMove = (event) => {
+      const nextWidth = Math.min(
+        MAX_SIDEBAR_WIDTH,
+        Math.max(MIN_SIDEBAR_WIDTH, event.clientX)
+      );
+      if (nextWidth >= MAX_SIDEBAR_WIDTH) {
+        reachedMaxDuringDragRef.current = true;
+      }
+      latestWidthRef.current = nextWidth;
+      onSidebarWidthChange?.(nextWidth);
+    };
+
+    const handlePointerUp = () => {
+      setIsResizing(false);
+      if (reachedMaxDuringDragRef.current) {
+        maxHitCountRef.current += 1;
+        if (maxHitCountRef.current >= MAX_HIT_TRIGGER) {
+          maxHitCountRef.current = 0;
+          onSidebarMaxedOut?.();
+        }
+      }
+    };
+
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    window.addEventListener("mousemove", handlePointerMove);
+    window.addEventListener("mouseup", handlePointerUp);
+
+    return () => {
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+      window.removeEventListener("mousemove", handlePointerMove);
+      window.removeEventListener("mouseup", handlePointerUp);
+    };
+  }, [isResizing, onSidebarWidthChange, onSidebarMaxedOut]);
+
+  const handleResetWidth = () => {
+    onSidebarWidthChange?.(DEFAULT_SIDEBAR_WIDTH);
+    maxHitCountRef.current = 0;
+  };
+
   return (
     <div className="flex flex-1 overflow-hidden">
       
@@ -16,11 +103,89 @@ export function DashboardLayout({
       )}
 
       <aside
-        className={`fixed inset-y-0 left-0 z-40 w-full max-w-sm transform transition-transform duration-300 ease-in-out bg-white dark:bg-slate-900 
-                   md:relative md:w-1/3 md:min-w-[320px] md:max-w-[480px] md:translate-x-0 md:border-r md:border-slate-200 md:dark:border-slate-800
+        style={{
+          "--sidebar-width": `${clampedSidebarWidth}px`,
+          "--sidebar-rail-width": `${COLLAPSED_SIDEBAR_WIDTH}px`,
+        }}
+        className={`fixed inset-y-0 left-0 z-40 w-full max-w-sm transform transition-all duration-300 ease-in-out bg-white dark:bg-slate-900 
+                   md:relative md:translate-x-0 md:border-r md:border-slate-200 md:dark:border-slate-800
+                   ${isSidebarCollapsed ? "md:w-[var(--sidebar-rail-width)] md:min-w-[var(--sidebar-rail-width)] md:max-w-[var(--sidebar-rail-width)]" : "md:w-[var(--sidebar-width)] md:min-w-[var(--sidebar-width)] md:max-w-[var(--sidebar-width)]"}
                    ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"}`}
       >
-        {sidebar}
+        <div className={`h-full ${isSidebarCollapsed ? "hidden md:hidden" : ""}`}>
+          {sidebar}
+        </div>
+        <div className={`h-full ${isSidebarCollapsed ? "hidden md:flex md:flex-col" : "hidden"}`}>
+          {collapsedSidebar}
+        </div>
+        <SidebarDiscoveryNudge
+          isVisible={showSidebarDiscovery && !isSidebarCollapsed}
+          sidebarWidth={clampedSidebarWidth}
+          shortcutLabel={sidebarShortcutLabel}
+          searchShortcutLabel={searchShortcutLabel}
+          onTry={onTrySidebarDiscovery}
+          onDismiss={onDismissSidebarDiscovery}
+        />
+        <div className="hidden md:flex absolute inset-y-0 -right-3 w-6 items-start justify-center">
+          {!isSidebarCollapsed && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Resize sidebar"
+                  onMouseDown={() => setIsResizing(true)}
+                  onDoubleClick={handleResetWidth}
+                  className="group absolute inset-y-0 left-[9px] flex w-[6px] cursor-col-resize items-center justify-center"
+                >
+                  <div
+                    className={`absolute inset-y-0 left-[2px] w-[2px] rounded-full transition-colors ${
+                      isResizing
+                        ? "bg-indigo-500 dark:bg-indigo-400"
+                        : "bg-slate-200/80 group-hover:bg-indigo-400 dark:bg-slate-700/80 dark:group-hover:bg-indigo-400"
+                    }`}
+                  />
+                  <div
+                    className={`pointer-events-none relative z-10 flex h-5 w-4 items-center justify-center rounded-sm bg-white text-indigo-500 shadow-sm transition-opacity dark:bg-slate-900 ${
+                      isResizing ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+                    }`}
+                  >
+                    <GripVertical className="h-3.5 w-3.5" />
+                  </div>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="right">Drag to resize • double-click to reset</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onToggleSidebarCollapsed}
+                className="hidden md:flex absolute -right-2 top-6 z-50 h-7 w-7 items-center justify-center rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 shadow-sm transition-colors"
+                aria-label={isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              >
+                {isSidebarCollapsed ? (
+                  <PanelLeft className="h-3.5 w-3.5" />
+                ) : (
+                  <PanelLeftClose className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {isSidebarCollapsed
+                ? `Expand sidebar • ${sidebarShortcutLabel}`
+                : `Collapse sidebar • ${sidebarShortcutLabel}`}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        {isResizing && !isSidebarCollapsed && (
+          <div
+            className="pointer-events-none fixed top-4 z-[100] rounded-md bg-slate-900/90 px-2 py-1 font-mono text-xs text-white shadow-lg dark:bg-slate-100/95 dark:text-slate-900"
+            style={{ left: `${clampedSidebarWidth + 14}px` }}
+          >
+            {clampedSidebarWidth}px
+          </div>
+        )}
       </aside>
 
       <div className="flex-1 flex flex-col overflow-y-auto">{children}</div>

--- a/frontend/src/components/layout/ServerCard.jsx
+++ b/frontend/src/components/layout/ServerCard.jsx
@@ -1,0 +1,234 @@
+import React, { useState, useEffect } from "react";
+import {
+  Trash2,
+  Server,
+  HardDrive,
+  Clock,
+  Zap,
+  Settings,
+  Pencil,
+  Container,
+  MoreVertical,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatBytes, formatUptime } from "@/lib/utils";
+
+function useRelativeTime(timestamp) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!timestamp) return;
+    const id = setInterval(() => setTick((t) => t + 1), 15000);
+    return () => clearInterval(id);
+  }, [timestamp]);
+  if (!timestamp) return null;
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 10) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function LastRefreshedLabel({ timestamp }) {
+  const label = useRelativeTime(timestamp);
+  if (!label) return null;
+  return (
+    <p className="mt-1.5 text-[10px] text-slate-400 dark:text-slate-500 tracking-wide">
+      Updated {label}
+    </p>
+  );
+}
+
+function ServerHealthDot({ ok, isUpdating }) {
+  const tone = isUpdating
+    ? "bg-blue-400 animate-pulse"
+    : ok !== false
+      ? "bg-green-500"
+      : "bg-red-500";
+  const label = isUpdating ? "Updating..." : ok !== false ? "Online" : "Unreachable";
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={`inline-block h-2 w-2 rounded-full flex-shrink-0 ${tone}`} />
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ServerCardActions({ server, onEdit, onDelete }) {
+  const showDelete = server.id !== "local";
+  return (
+    <>
+      <div className="hidden md:flex items-center space-x-2 opacity-40 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button
+          onClick={(e) => { e.stopPropagation(); onEdit(server.id); }}
+          className="p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400"
+          aria-label="Edit Server"
+        >
+          <Pencil className="h-4 w-4" />
+        </button>
+        {showDelete && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onDelete(server); }}
+            className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-500"
+            aria-label="Delete Server"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <div className="md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400"
+              aria-label="More options"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent onClick={(e) => e.stopPropagation()} align="end">
+            <DropdownMenuItem onClick={() => onEdit(server.id)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              <span>Edit</span>
+            </DropdownMenuItem>
+            {showDelete && (
+              <DropdownMenuItem
+                onClick={() => onDelete(server)}
+                className="text-red-600 focus:text-red-600 dark:text-red-500 dark:focus:text-red-500"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                <span>Delete</span>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </>
+  );
+}
+
+function ServerCardMetrics({ memory, uptime, portCount, typeIcon, typeCount, typeLabel }) {
+  return (
+    <>
+      <div className="mt-3 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors">
+        <div className="flex items-center space-x-3">
+          <HardDrive className="h-3 w-3 mr-1" />
+          <span>{memory ? formatBytes(memory) : "N/A"}</span>
+        </div>
+        <div className="flex items-center space-x-3">
+          <Clock className="h-3 w-3 mr-1" />
+          <span>{uptime ? formatUptime(uptime, true) : "N/A"}</span>
+        </div>
+      </div>
+      <div className="mt-2 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors">
+        <div className="flex items-center space-x-3">
+          <Zap className="h-3 w-3 mr-1" />
+          <span>{portCount} ports</span>
+        </div>
+        <div className="flex items-center space-x-3">
+          {typeIcon}
+          <span>{typeCount} {typeLabel}</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function getHostDisplay(server, hostOverride) {
+  if (!server.url) return hostOverride || window.location.host || "localhost";
+  try {
+    const url = new URL(server.url.startsWith("http") ? server.url : `http://${server.url}`);
+    const portSuffix = url.port && url.port !== "80" && url.port !== "443" ? `:${url.port}` : "";
+    return url.hostname + portSuffix;
+  } catch {
+    return server.url.replace(/^https?:\/\//, "").replace(/\/.*$/, "") || "localhost";
+  }
+}
+
+function getServerTypeMeta(server, portCount, containerCount, vmCount) {
+  if (server.platform === "docker" || containerCount > 0) {
+    return {
+      label: containerCount === 1 ? "Container" : "Containers",
+      icon: <Container className="h-3 w-3 mr-1" />,
+      count: containerCount,
+    };
+  }
+  if (vmCount > 0) {
+    return { label: "VMs", icon: <Server className="h-3 w-3 mr-1" />, count: vmCount };
+  }
+  return { label: "Services", icon: <Settings className="h-3 w-3 mr-1" />, count: portCount };
+}
+
+export const ServerCard = React.memo(function ServerCard({
+  server,
+  isSelected,
+  onSelect,
+  onEdit,
+  onDelete,
+  hostOverride,
+  lastRefreshedTs,
+  children,
+}) {
+  const name = server.server || "Unknown Server";
+  const portCount = server.data?.length || 0;
+  const isUpdating = server.ok === null || server.loading;
+  const systemInfo = server.systemInfo || {};
+  const memory = systemInfo.physmem || systemInfo.total_mem || systemInfo.memory;
+  const uptime = systemInfo.uptime_seconds;
+  const containerCount = systemInfo.containers_running || 0;
+  const vmCount = (server.vms || []).length;
+  const typeMeta = getServerTypeMeta(server, portCount, containerCount, vmCount);
+  const cardClass = `p-4 rounded-xl border-2 transition-all duration-200 group relative focus:outline-none ${
+    isSelected
+      ? "border-blue-500 bg-blue-50 dark:bg-slate-800 shadow-md hover:shadow-lg hover:border-blue-600"
+      : "border-slate-200 dark:border-slate-700/50 hover:bg-slate-50 dark:hover:bg-slate-800/50 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm"
+  } ${isUpdating ? "opacity-75 cursor-not-allowed" : "cursor-pointer"}`;
+
+  return (
+    <div
+      tabIndex={0}
+      onClick={(e) => { e.stopPropagation(); onSelect(server.id); }}
+      className={cardClass}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <h4 className="font-semibold text-slate-800 dark:text-slate-200 truncate pr-2 group-hover:text-slate-900 dark:group-hover:text-slate-100 transition-colors flex items-center gap-2">
+            {server.label || name}
+            <ServerHealthDot ok={server.ok} isUpdating={isUpdating} />
+          </h4>
+          <p className="text-xs text-slate-500 dark:text-slate-400 truncate mt-0.5 font-mono">
+            {getHostDisplay(server, hostOverride)}
+          </p>
+        </div>
+        <ServerCardActions server={server} onEdit={onEdit} onDelete={onDelete} />
+      </div>
+      <ServerCardMetrics
+        memory={memory}
+        uptime={uptime}
+        portCount={portCount}
+        typeIcon={typeMeta.icon}
+        typeCount={typeMeta.count}
+        typeLabel={typeMeta.label}
+      />
+      {lastRefreshedTs && <LastRefreshedLabel timestamp={lastRefreshedTs} />}
+      {children}
+    </div>
+  );
+});

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,20 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import {
-  Trash2,
   Plus,
   Check,
   X,
-  Server,
-  HardDrive,
-  Clock,
-  Zap,
   BarChart3,
-  Settings,
   Loader2,
   AlertCircle,
-  Pencil,
-  Container,
-  MoreVertical,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -29,14 +20,8 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { formatBytes, formatUptime } from "@/lib/utils";
 import { SidebarSkeleton } from "./SidebarSkeleton";
+import { ServerCard } from "./ServerCard";
 
 const generateServerId = (label) => {
   if (!label || !label.trim()) {
@@ -55,162 +40,6 @@ const generateServerId = (label) => {
   return cleanId.substring(0, 50);
 };
 
-const ServerCard = React.memo(function ServerCard({
-  server,
-  isSelected,
-  onSelect,
-  onEdit,
-  onDelete,
-  hostOverride,
-  children,
-}) {
-  const name = server.server || "Unknown Server";
-  const portCount = server.data?.length || 0;
-  const isUpdating = server.ok === null || server.loading;
-  const systemInfo = server.systemInfo || {};
-  const vms = server.vms || [];
-  const memory =
-    systemInfo.physmem || systemInfo.total_mem || systemInfo.memory;
-  const uptime = systemInfo.uptime_seconds;
-  const containerCount = systemInfo.containers_running || 0;
-  const vmCount = vms.length;
-
-  const getHostDisplay = () => {
-    if (!server.url) {
-      return hostOverride || window.location.host || "localhost";
-    }
-    
-    try {
-      const url = new URL(server.url.startsWith('http') ? server.url : `http://${server.url}`);
-      return url.hostname + (url.port && url.port !== '80' && url.port !== '443' ? `:${url.port}` : '');
-    } catch {
-      return server.url.replace(/^https?:\/\//, '').replace(/\/.*$/, '') || "localhost";
-    }
-  };
-
-  let typeLabel = "Services";
-  let typeIcon = <Settings className="h-3 w-3 mr-1" />;
-  let typeCount = portCount;
-  if (server.platform === "docker" || containerCount > 0) {
-    typeLabel = containerCount === 1 ? "Container" : "Containers";
-    typeIcon = <Container className="h-3 w-3 mr-1" />;
-    typeCount = containerCount;
-  } else if (vmCount > 0) {
-    typeLabel = "VMs";
-    typeIcon = <Server className="h-3 w-3 mr-1" />;
-    typeCount = vmCount;
-  }
-
-  return (
-    <div
-      tabIndex={0}
-      onClick={(e) => {
-        e.stopPropagation();
-        onSelect(server.id);
-      }}
-      className={`p-4 rounded-xl border-2 transition-all duration-200 group relative focus:outline-none ${
-        isSelected
-          ? "border-blue-500 bg-blue-50 dark:bg-slate-800 shadow-md hover:shadow-lg hover:border-blue-600"
-          : "border-slate-200 dark:border-slate-700/50 hover:bg-slate-50 dark:hover:bg-slate-800/50 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm"
-      } ${isUpdating ? "opacity-75 cursor-not-allowed" : "cursor-pointer"}`}
-    >
-      <div className="flex items-center justify-between">
-        <div className="flex-1 min-w-0">
-          <h4 className="font-semibold text-slate-800 dark:text-slate-200 truncate pr-2 group-hover:text-slate-900 dark:group-hover:text-slate-100 transition-colors flex items-center">
-            {server.label || name}
-          </h4>
-          <p className="text-xs text-slate-500 dark:text-slate-400 truncate mt-0.5 font-mono">
-            {getHostDisplay()}
-          </p>
-        </div>
-
-        <div className="hidden md:flex items-center space-x-2 opacity-40 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit(server.id);
-            }}
-            className="p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400"
-            aria-label="Edit Server"
-          >
-            <Pencil className="h-4 w-4" />
-          </button>
-          {server.id !== "local" && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(server);
-              }}
-              className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-500"
-              aria-label="Delete Server"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          )}
-        </div>
-
-        <div className="md:hidden">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                onClick={(e) => e.stopPropagation()}
-                className="p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400"
-                aria-label="More options"
-              >
-                <MoreVertical className="h-4 w-4" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              onClick={(e) => e.stopPropagation()}
-              align="end"
-            >
-              <DropdownMenuItem onClick={() => onEdit(server.id)}>
-                <Pencil className="mr-2 h-4 w-4" />
-                <span>Edit</span>
-              </DropdownMenuItem>
-        
-              {server.id !== "local" && (
-                <DropdownMenuItem
-                  onClick={() => onDelete(server)}
-                  className="text-red-600 focus:text-red-600 dark:text-red-500 dark:focus:text-red-500"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  <span>Delete</span>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-
-        
-      <div className="mt-3 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors">
-        <div className="flex items-center space-x-3">
-          <HardDrive className="h-3 w-3 mr-1" />
-          <span>{memory ? formatBytes(memory) : "N/A"}</span>
-        </div>
-        <div className="flex items-center space-x-3">
-          <Clock className="h-3 w-3 mr-1" />
-          <span>{uptime ? formatUptime(uptime, true) : "N/A"}</span>
-        </div>
-      </div>
-      <div className="mt-2 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors">
-        <div className="flex items-center space-x-3">
-          <Zap className="h-3 w-3 mr-1" />
-          <span>{portCount} ports</span>
-        </div>
-        <div className="flex items-center space-x-3">
-          {typeIcon}
-          <span>
-            {typeCount} {typeLabel}
-          </span>
-        </div>
-      </div>
-      {children}
-    </div>
-  );
-});
-
 export function Sidebar({
   servers,
   selectedId,
@@ -219,6 +48,9 @@ export function Sidebar({
   onDelete,
   loading,
   hostOverride,
+  lastRefreshedAt = {},
+  requestedMode,
+  onRequestedModeHandled,
 }) {
   const [mode, setMode] = useState("list");
   const [form, setForm] = useState({
@@ -237,6 +69,15 @@ export function Sidebar({
   const [submitting, setSubmitting] = useState(false);
   const [validationStatus, setValidationStatus] = useState(null);
   const latestValidationRef = useRef(0);
+
+  useEffect(() => {
+    if (!requestedMode) {
+      return;
+    }
+
+    setMode(requestedMode);
+    onRequestedModeHandled?.();
+  }, [requestedMode, onRequestedModeHandled]);
 
   useEffect(() => {
     if (mode !== "add" && mode !== "list") {
@@ -510,6 +351,7 @@ export function Sidebar({
         onEdit={setMode}
         onDelete={setServerToDelete}
         hostOverride={hostOverride}
+        lastRefreshedTs={lastRefreshedAt[server.id]}
       >
         {children.length > 0 && level < maxIndentLevel && (
           <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700/50 space-y-3">

--- a/frontend/src/components/layout/SidebarDiscoveryNudge.jsx
+++ b/frontend/src/components/layout/SidebarDiscoveryNudge.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { Sparkles, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function SidebarDiscoveryNudge({
+  isVisible,
+  sidebarWidth,
+  shortcutLabel,
+  searchShortcutLabel,
+  onTry,
+  onDismiss,
+}) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="hidden md:block fixed top-24 z-50 w-80 animate-in fade-in-0 slide-in-from-left-2 duration-300"
+      style={{ left: `${sidebarWidth + 24}px` }}
+    >
+      <div className="rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-2xl backdrop-blur-sm dark:border-slate-700 dark:bg-slate-800/95">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-indigo-600 dark:bg-indigo-900/60 dark:text-indigo-300">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  Heads up — sidebar has knobs.
+                </p>
+                <p className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                  Drag the edge to resize. <kbd className="rounded border border-slate-200 bg-slate-50 px-1 font-mono text-[11px] text-slate-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300">{shortcutLabel}</kbd> folds it away. <kbd className="rounded border border-slate-200 bg-slate-50 px-1 font-mono text-[11px] text-slate-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300">{searchShortcutLabel}</kbd> jumps into search.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onDismiss(dontShowAgain)}
+                className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                aria-label="Close sidebar tip"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <label className="mt-3 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+              <input
+                type="checkbox"
+                checked={dontShowAgain}
+                onChange={(event) => setDontShowAgain(event.target.checked)}
+                className="h-3.5 w-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
+              />
+              Stop reminding me
+            </label>
+
+            <div className="mt-4 flex items-center gap-2">
+              <Button size="sm" onClick={onTry} className="h-8 px-3">
+                Got it
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => onDismiss(dontShowAgain)}
+                className="h-8 px-2 text-slate-500 dark:text-slate-400"
+              >
+                Not now
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SidebarDiscoveryNudge;

--- a/frontend/src/components/server/AggregatedHealthDot.jsx
+++ b/frontend/src/components/server/AggregatedHealthDot.jsx
@@ -5,18 +5,103 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useServiceHealth } from "@/hooks/useServiceHealth";
+import { WhyThisStatusPopover } from "./WhyThisStatusPopover";
+
+const COLOR_CLASSES = {
+  green: "bg-green-500",
+  yellow: "bg-yellow-500",
+  red: "bg-red-500",
+  gray: "bg-gray-400",
+};
+
+function stopStatusEvent(event) {
+  event.stopPropagation();
+}
+
+function deriveStatusesFromComponents(components, ports) {
+  const out = {};
+  if (!Array.isArray(components) || !Array.isArray(ports)) return out;
+  const byContainer = new Map();
+  components.forEach((c) => {
+    if (c && c.containerId) byContainer.set(c.containerId, c);
+  });
+  const samePort = (a, b) => Number(a) === Number(b);
+  const matchesEntry = (entry, port) => {
+    if (!entry) return false;
+    if (!samePort(entry.host_port, port.host_port)) return false;
+    if (!entry.host_ip || !port.host_ip) return true;
+    return entry.host_ip === port.host_ip;
+  };
+  ports.forEach((port) => {
+    if (!port || port.host_ip == null || port.host_port == null) return;
+    const key = `${port.host_ip}:${port.host_port}`;
+    const comp = port.container_id ? byContainer.get(port.container_id) : null;
+    if (!comp) return;
+    const probe = comp.probe || {};
+    const evidence = probe.evidence || {};
+    const failures = Array.isArray(evidence.failures) ? evidence.failures : [];
+    const suppressed = Array.isArray(evidence.suppressed) ? evidence.suppressed : [];
+    const failure = failures.find((f) => matchesEntry(f, port));
+    if (failure) {
+      out[key] = { color: 'red', reason: failure.error || 'unreachable', isInternal: !!port.internal };
+      return;
+    }
+    const supp = suppressed.find((s) => matchesEntry(s, port));
+    if (supp) {
+      out[key] = { color: 'gray', suppressed: true, suppressedReason: supp.reason || 'unknown', isInternal: !!port.internal };
+      return;
+    }
+    out[key] = { color: probe.ok === true ? 'green' : 'red', isInternal: !!port.internal };
+  });
+  return out;
+}
+
+function shortStatusReason(reason, colorWord) {
+  if (!reason) return colorWord;
+
+  const legacyPartial = reason.match(/^HEALTHCHECK ok but (\d+) port\(s\) unreachable:/i);
+  if (legacyPartial) {
+    const count = Number(legacyPartial[1]);
+    return `Service is running, but ${count} published port${count === 1 ? "" : "s"} aren't responding`;
+  }
+
+  return reason
+    .replace(/\bdid not answer\b/gi, "aren't responding")
+    .replace(/\bHEALTHCHECK\b/g, "health check")
+    .replace(/\bcore component(s)?\b/gi, "main service$1")
+    .replace(/\bcore service\(s\)\b/gi, "main service(s)");
+}
 
 export function AggregatedHealthDot({
   ports,
   serverId,
   serverUrl,
+  hostOverride,
+  serviceName,
+  isDocker,
 }) {
   const [portStatuses, setPortStatuses] = useState({});
   const [checking, setChecking] = useState(true);
   const abortControllerRef = useRef(null);
+  const sh = useServiceHealth();
+  const isLocal = !serverId || serverId === "local";
+  const composeProject = (ports || []).find((p) => p && p.compose_project)?.compose_project || null;
+  const containerIds = Array.from(
+    new Set((ports || []).map((p) => p && p.container_id).filter(Boolean))
+  );
+  const anyContainerId = containerIds[0] || null;
+  const shLookup = sh.enabled && isLocal
+    ? sh.lookupCard({ isDocker, composeProject, serviceName, containerId: anyContainerId, containerIds })
+    : null;
+  const shHasVerdict = !!(shLookup && shLookup.color);
 
   useEffect(() => {
     if (!ports || ports.length === 0) {
+      setChecking(false);
+      return;
+    }
+    if (shHasVerdict) {
       setChecking(false);
       return;
     }
@@ -102,7 +187,7 @@ export function AggregatedHealthDot({
     return () => {
       abortControllerRef.current?.abort();
     };
-  }, [ports, serverId, serverUrl]);
+  }, [ports, serverId, serverUrl, shHasVerdict]);
 
   const getAggregatedState = () => {
     if (checking || Object.keys(portStatuses).length === 0) {
@@ -164,6 +249,87 @@ export function AggregatedHealthDot({
 
   const state = getAggregatedState();
 
+  const [explainerOpen, setExplainerOpen] = useState(false);
+
+  if (isLocal && sh.loading) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="relative flex-shrink-0">
+              <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[230px]">
+            <p className="font-medium text-xs">Checking service health...</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  if (shLookup && shLookup.color) {
+    const colorClass = COLOR_CLASSES[shLookup.color] || COLOR_CLASSES.gray;
+    const colorWord = {
+      green: "All reachable",
+      yellow: "Partially reachable",
+      red: "Main component unreachable",
+      gray: "Status unclear",
+    }[shLookup.color] || "Service health";
+    const title = shortStatusReason(shLookup.reason, colorWord);
+    return (
+      <>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setExplainerOpen(true); }}
+                onMouseDown={stopStatusEvent}
+                onPointerDown={stopStatusEvent}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setExplainerOpen(true);
+                  }
+                }}
+                className="relative flex flex-shrink-0 cursor-pointer items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+                aria-label={`Service status: ${title}. Open details.`}
+              >
+                <div className={`w-2 h-2 rounded-full ${colorClass}`} />
+                <span aria-hidden="true" className="absolute -inset-2" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent
+              className="max-w-[230px]"
+              onClick={stopStatusEvent}
+              onMouseDown={stopStatusEvent}
+              onPointerDown={stopStatusEvent}
+            >
+              <p className="font-medium text-xs leading-snug">{title}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <WhyThisStatusPopover
+          open={explainerOpen}
+          onOpenChange={setExplainerOpen}
+          serviceName={serviceName || (shLookup.services[0] && shLookup.services[0].name) || "service"}
+          color={shLookup.color}
+          reason={shLookup.reason}
+          components={shLookup.components}
+          ports={ports}
+          portStatuses={deriveStatusesFromComponents(shLookup.components, ports)}
+          updatedAt={sh.updatedAt}
+          onRefresh={sh.refresh}
+          serverId={serverId}
+          serverUrl={serverUrl}
+          hostOverride={hostOverride}
+        />
+      </>
+    );
+  }
+
   return (
     <TooltipProvider>
       <Tooltip>
@@ -175,7 +341,12 @@ export function AggregatedHealthDot({
             )}
           </div>
         </TooltipTrigger>
-        <TooltipContent>
+        <TooltipContent
+          className="max-w-[230px]"
+          onClick={stopStatusEvent}
+          onMouseDown={stopStatusEvent}
+          onPointerDown={stopStatusEvent}
+        >
           <p className="font-medium text-xs">{state.title}</p>
           {state.hasNoWebUI && (
             <p className="text-xs text-slate-400">Some ports have no web UI</p>

--- a/frontend/src/components/server/AggregatedHealthDot.jsx
+++ b/frontend/src/components/server/AggregatedHealthDot.jsx
@@ -59,18 +59,7 @@ function deriveStatusesFromComponents(components, ports) {
 
 function shortStatusReason(reason, colorWord) {
   if (!reason) return colorWord;
-
-  const legacyPartial = reason.match(/^HEALTHCHECK ok but (\d+) port\(s\) unreachable:/i);
-  if (legacyPartial) {
-    const count = Number(legacyPartial[1]);
-    return `Service is running, but ${count} published port${count === 1 ? "" : "s"} aren't responding`;
-  }
-
-  return reason
-    .replace(/\bdid not answer\b/gi, "aren't responding")
-    .replace(/\bHEALTHCHECK\b/g, "health check")
-    .replace(/\bcore component(s)?\b/gi, "main service$1")
-    .replace(/\bcore service\(s\)\b/gi, "main service(s)");
+  return reason;
 }
 
 export function AggregatedHealthDot({
@@ -193,7 +182,7 @@ export function AggregatedHealthDot({
     if (checking || Object.keys(portStatuses).length === 0) {
       return {
         color: "bg-blue-400 animate-pulse",
-        title: "Checking health...",
+        title: "Checking…",
         hasNoWebUI: false,
       };
     }
@@ -261,7 +250,7 @@ export function AggregatedHealthDot({
             </div>
           </TooltipTrigger>
           <TooltipContent className="max-w-[230px]">
-            <p className="font-medium text-xs">Checking service health...</p>
+            <p className="font-medium text-xs">Checking…</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -273,7 +262,7 @@ export function AggregatedHealthDot({
     const colorWord = {
       green: "All reachable",
       yellow: "Partially reachable",
-      red: "Main component unreachable",
+      red: "Main service unreachable",
       gray: "Status unclear",
     }[shLookup.color] || "Service health";
     const title = shortStatusReason(shLookup.reason, colorWord);

--- a/frontend/src/components/server/InternalPortDetails.jsx
+++ b/frontend/src/components/server/InternalPortDetails.jsx
@@ -278,7 +278,7 @@ export function InternalPortDetails({ open, onOpenChange, containerId, serverId 
                               </span>
                             ) : (
                               <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 text-[10px] font-medium">
-                                no healthcheck
+                                no health check
                               </span>
                             )}
                           </div>
@@ -730,10 +730,6 @@ export function InternalPortDetails({ open, onOpenChange, containerId, serverId 
   );
 }
 
-
-/**
- * Clock icon component
- */
 function ClockIcon(props) {
   return (
     <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-slate-600 dark:text-slate-400" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>

--- a/frontend/src/components/server/PortCard.jsx
+++ b/frontend/src/components/server/PortCard.jsx
@@ -72,7 +72,9 @@ function PortCardComponent({
   const shouldHighlight = !!searchTerm;
 
   let hostForUi;
-  if (port.host_ip === "0.0.0.0" || port.host_ip === "127.0.0.1") {
+  if (port.host_ip === "127.0.0.1") {
+    hostForUi = "127.0.0.1";
+  } else if (port.host_ip === "0.0.0.0") {
     if (serverId === "local") {
       hostForUi = hostOverride || window.location.hostname;
     } else if (serverUrl) {
@@ -92,6 +94,7 @@ function PortCardComponent({
   return (
     <li
       tabIndex="0"
+      data-port-row={String(port.host_port)}
       className={`flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors group focus:outline-none focus:bg-slate-50 dark:focus:bg-slate-800/50 ${
         isSelected ? 'bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500' : ''
       }`}

--- a/frontend/src/components/server/PortGridItem.jsx
+++ b/frontend/src/components/server/PortGridItem.jsx
@@ -42,11 +42,6 @@ const getDisplayServiceName = (port) => {
   return port.customServiceName || port.owner || "Unknown Service";
 };
 
-/**
- * Displays detailed information and interactive actions for a network port, with optional search term highlighting.
- *
- * Renders a styled UI card showing port status, clickable port number, internal port details, owner, notes, source, creation date, and host information. Provides actions for copying, editing notes, and toggling ignore state, with dynamic highlighting of search matches.
- */
 export function PortGridItem({
   port,
   serverId,
@@ -77,7 +72,9 @@ export function PortGridItem({
   const shouldHighlight = !!searchTerm;
 
   let hostForUi;
-  if (port.host_ip === "0.0.0.0" || port.host_ip === "127.0.0.1") {
+  if (port.host_ip === "127.0.0.1") {
+    hostForUi = "127.0.0.1";
+  } else if (port.host_ip === "0.0.0.0") {
     if (serverId === "local") {
       hostForUi = hostOverride || window.location.hostname;
     } else if (serverUrl) {

--- a/frontend/src/components/server/PortStatusIndicator.jsx
+++ b/frontend/src/components/server/PortStatusIndicator.jsx
@@ -5,6 +5,36 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useServiceHealth } from "@/hooks/useServiceHealth";
+
+const FEAT_COLOR_CLASSES = {
+  green: "bg-green-500",
+  yellow: "bg-yellow-500",
+  red: "bg-red-500",
+  gray: "bg-gray-400",
+};
+
+function samePort(a, b) {
+  return Number(a) === Number(b);
+}
+
+function failureForPort(port, failures) {
+  if (!Array.isArray(failures)) return null;
+  return failures.find((failure) => {
+    if (!samePort(failure.host_port, port.host_port)) return false;
+    if (!failure.host_ip || !port.host_ip) return true;
+    return failure.host_ip === port.host_ip;
+  }) || null;
+}
+
+function suppressedForPort(port, suppressed) {
+  if (!Array.isArray(suppressed)) return null;
+  return suppressed.find((entry) => {
+    if (!samePort(entry.host_port, port.host_port)) return false;
+    if (!entry.host_ip || !port.host_ip) return true;
+    return entry.host_ip === port.host_ip;
+  }) || null;
+}
 
 export function PortStatusIndicator({
   serverId,
@@ -12,10 +42,21 @@ export function PortStatusIndicator({
   port,
   onProtocolChange,
 }) {
+  const sh = useServiceHealth();
+  const isLocal = !serverId || serverId === "local";
+  const shHit = sh.enabled && isLocal && port.container_id
+    ? sh.lookupPort({ container_id: port.container_id })
+    : null;
+  const shHasVerdict = !!(shHit && shHit.component);
+
   const [statusData, setStatusData] = useState(null);
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
+    if (shHasVerdict) {
+      setChecking(false);
+      return undefined;
+    }
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000);
 
@@ -76,7 +117,7 @@ export function PortStatusIndicator({
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [port.host_ip, port.host_port, port.owner, port.internal, port.container_id, port.source, serverId, serverUrl, onProtocolChange]);
+  }, [shHasVerdict, port.host_ip, port.host_port, port.owner, port.internal, port.container_id, port.source, serverId, serverUrl, onProtocolChange]);
 
   const getDotState = () => {
     if (checking) {
@@ -112,10 +153,57 @@ export function PortStatusIndicator({
   const dotState = getDotState();
   const showNoWebUIIndicator = !checking && statusData?.color === 'green' && !dotState.hasWebUI;
 
+  if (shHasVerdict) {
+    const comp = shHit.component;
+    const probe = comp.probe || {};
+    const evidence = probe.evidence || {};
+    const failures = Array.isArray(evidence.failures) ? evidence.failures : [];
+    const suppressed = Array.isArray(evidence.suppressed) ? evidence.suppressed : [];
+    const failedHere = failureForPort(port, failures);
+    const suppressedHere = !failedHere ? suppressedForPort(port, suppressed) : null;
+    const ok = probe.ok === true;
+    let probeColor;
+    let summary;
+    let detail;
+    if (suppressedHere) {
+      probeColor = 'gray';
+      summary = 'host-only';
+      detail = 'Bound to 127.0.0.1, so it is reachable only from the machine running the container.';
+    } else if (failedHere) {
+      probeColor = 'red';
+      summary = 'Port unreachable';
+      detail = "This published port isn't responding. The container itself appears to be running normally.";
+    } else if (ok) {
+      probeColor = 'green';
+      summary = 'reachable';
+      detail = comp.reason;
+    } else {
+      probeColor = 'red';
+      summary = probe.error || 'unreachable';
+      detail = comp.reason;
+    }
+    const colorClass = FEAT_COLOR_CLASSES[probeColor];
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="relative">
+              <div className={`w-2.5 h-2.5 rounded-full ${colorClass}`} />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-medium">{summary}</p>
+            {detail && <p className="text-xs text-slate-400">{detail}</p>}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <div className="relative">
             <div className={`w-2.5 h-2.5 rounded-full ${dotState.color}`} />
             {showNoWebUIIndicator && (

--- a/frontend/src/components/server/PortStatusIndicator.jsx
+++ b/frontend/src/components/server/PortStatusIndicator.jsx
@@ -168,7 +168,7 @@ export function PortStatusIndicator({
     if (suppressedHere) {
       probeColor = 'gray';
       summary = 'host-only';
-      detail = 'Bound to 127.0.0.1, so it is reachable only from the machine running the container.';
+      detail = 'Bound to 127.0.0.1';
     } else if (failedHere) {
       probeColor = 'red';
       summary = 'Port unreachable';

--- a/frontend/src/components/server/PortStatusIndicator.jsx
+++ b/frontend/src/components/server/PortStatusIndicator.jsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useServiceHealth } from "@/hooks/useServiceHealth";
+import { humanizeProbeError } from "@/lib/health-copy";
 
 const FEAT_COLOR_CLASSES = {
   green: "bg-green-500",
@@ -171,16 +172,16 @@ export function PortStatusIndicator({
       detail = 'Bound to 127.0.0.1';
     } else if (failedHere) {
       probeColor = 'red';
-      summary = 'Port unreachable';
-      detail = "This published port isn't responding. The container itself appears to be running normally.";
+      summary = 'unreachable';
+      detail = "Container is running, but the port isn't responding.";
     } else if (ok) {
       probeColor = 'green';
       summary = 'reachable';
       detail = comp.reason;
     } else {
       probeColor = 'red';
-      summary = probe.error || 'unreachable';
-      detail = comp.reason;
+      summary = 'unreachable';
+      detail = humanizeProbeError(probe.error) || comp.reason;
     }
     const colorClass = FEAT_COLOR_CLASSES[probeColor];
     return (

--- a/frontend/src/components/server/PortTableRow.jsx
+++ b/frontend/src/components/server/PortTableRow.jsx
@@ -72,7 +72,9 @@ function PortTableRowComponent({
   const shouldHighlight = !!searchTerm;
 
   let hostForUi;
-  if (port.host_ip === "0.0.0.0" || port.host_ip === "127.0.0.1") {
+  if (port.host_ip === "127.0.0.1") {
+    hostForUi = "127.0.0.1";
+  } else if (port.host_ip === "0.0.0.0") {
     if (serverId === "local") {
       hostForUi = hostOverride || window.location.hostname;
     } else if (serverUrl) {

--- a/frontend/src/components/server/ServerSection.jsx
+++ b/frontend/src/components/server/ServerSection.jsx
@@ -53,12 +53,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { collectKnownComposeProjects, inferComposeProjectFor } from "./compose-attribution";
 
-/**
- * Renders a comprehensive server overview section, including system information, virtual machines, and port management with sorting, filtering, and multiple layout options.
- *
- * Displays server status, host details, and provides interactive controls for sorting and viewing ports in list, grid, card, or table formats. Allows toggling between expanded and collapsed views, managing hidden ports, and switching layouts for system info and VMs. Handles user actions such as copying, editing notes, and toggling port visibility.
- */
 function ServerSectionComponent({
   server,
   ok,
@@ -228,15 +224,18 @@ function ServerSectionComponent({
     if (groupingMode !== "services") return [];
     
     const serviceMap = new Map();
+    const knownComposeProjects = collectKnownComposeProjects(sortedPorts);
+    const inferComposeProject = (port) => inferComposeProjectFor(port, knownComposeProjects);
     
     sortedPorts.forEach((port) => {
       let serviceKey;
       let serviceName;
       
       if (port.source === "docker") {
-        if (port.compose_project) {
-          serviceKey = `docker:${port.compose_project}`;
-          serviceName = port.compose_project;
+        const composeProject = inferComposeProject(port);
+        if (composeProject) {
+          serviceKey = `docker:${composeProject}`;
+          serviceName = composeProject;
         } else {
           serviceKey = `docker:${port.container_id || port.owner}`;
           serviceName = port.customServiceName || port.owner || "Unknown Container";
@@ -989,9 +988,7 @@ function ServerSectionComponent({
             <>
             {portLayout === "list" && (
               <>
-                {/**
-                 * Select all header for non-table views
-                 */}
+                {}
                 {selectionMode && (
                   <div className="flex items-center justify-between p-3 bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700">
                     <div className="flex items-center space-x-3">
@@ -1066,9 +1063,7 @@ function ServerSectionComponent({
 
             {portLayout === "grid" && (
               <>
-                {/**
-                 * Select all header for grid view
-                 */}
+                {}
                 {selectionMode && (
                   <div className="flex items-center justify-between p-3 bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700 mb-4">
                     <div className="flex items-center space-x-3">

--- a/frontend/src/components/server/ServiceCardGrid.jsx
+++ b/frontend/src/components/server/ServiceCardGrid.jsx
@@ -100,7 +100,7 @@ export function ServiceCardGrid({
         <div className={`flex items-start justify-between mb-3 ${selectionMode ? "ml-6" : ""}`}>
           <div className="flex items-center space-x-2 min-w-0 flex-1">
             {showIcons && <ServiceIcon name={serviceName} source={isDocker ? "docker" : "system"} size={24} className="flex-shrink-0" />}
-            <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} />
+            <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} hostOverride={hostOverride} serviceName={serviceName} isDocker={isDocker} />
             <div className="min-w-0 flex-1">
               <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 truncate">
                 {serviceName}

--- a/frontend/src/components/server/ServiceCardList.jsx
+++ b/frontend/src/components/server/ServiceCardList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -91,11 +91,7 @@ export function ServiceCardList({
           )}
 
           <div className="flex items-center">
-            {isExpanded ? (
-              <ChevronDown className="h-5 w-5 text-slate-400" />
-            ) : (
-              <ChevronRight className="h-5 w-5 text-slate-400" />
-            )}
+            <ChevronRight className={`h-5 w-5 text-slate-400 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`} />
           </div>
 
           {showIcons && <ServiceIcon name={serviceName} source={isDocker ? "docker" : "system"} size={24} />}
@@ -171,7 +167,7 @@ export function ServiceCardList({
       </div>
 
       {isExpanded && (
-        <div className="border-t border-slate-200 dark:border-slate-700">
+        <div className="border-t border-slate-200 dark:border-slate-700 animate-in fade-in-0 slide-in-from-top-1 duration-200">
           {(() => {
             const containerGroups = new Map();
             ports.forEach((port) => {

--- a/frontend/src/components/server/ServiceCardList.jsx
+++ b/frontend/src/components/server/ServiceCardList.jsx
@@ -71,8 +71,12 @@ export function ServiceCardList({
   };
 
   return (
-    <div className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden bg-white dark:bg-slate-800/50">
+    <div
+      className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden bg-white dark:bg-slate-800/50"
+      data-service-name={serviceName}
+    >
       <div
+        data-service-card-header="true"
         onClick={() => setIsExpanded(!isExpanded)}
         className="flex items-center justify-between p-4 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
       >
@@ -96,7 +100,7 @@ export function ServiceCardList({
 
           {showIcons && <ServiceIcon name={serviceName} source={isDocker ? "docker" : "system"} size={24} />}
 
-          <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} />
+          <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} hostOverride={hostOverride} serviceName={serviceName} isDocker={isDocker} />
 
           <div className="flex flex-col">
             <div className="flex items-center space-x-2">

--- a/frontend/src/components/server/ServiceCardTable.jsx
+++ b/frontend/src/components/server/ServiceCardTable.jsx
@@ -100,7 +100,7 @@ export function ServiceCardTableRow({
               }`} 
             />
             {showIcons && <ServiceIcon name={serviceName} source={isDocker ? "docker" : "system"} size={20} className="flex-shrink-0" />}
-            <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} />
+            <AggregatedHealthDot ports={ports} serverId={serverId} serverUrl={serverUrl} hostOverride={hostOverride} serviceName={serviceName} isDocker={isDocker} />
             <span className="font-medium text-sm text-slate-900 dark:text-slate-100">
               {serviceName}
             </span>

--- a/frontend/src/components/server/WhyThisStatusPopover.jsx
+++ b/frontend/src/components/server/WhyThisStatusPopover.jsx
@@ -1,0 +1,335 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+import { useOverrides } from '@/hooks/useOverrides';
+import { getDisplayHost } from './expanded-view-utils';
+
+const COLOR_CLASSES = {
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  red: 'bg-red-500',
+  gray: 'bg-gray-400',
+};
+
+const SIMPLE_ROLE = {
+  core_access: { label: 'main', tone: 'blue' },
+  core_runtime: { label: 'main', tone: 'blue' },
+  support: { label: 'helper', tone: 'slate' },
+  job_expected_exit: { label: 'finished', tone: 'slate' },
+  unknown: { label: 'unclear', tone: 'slate' },
+};
+
+const ROLE_OPTIONS = [
+  { value: 'auto', label: 'Auto (detect)' },
+  { value: 'core_runtime', label: 'Main' },
+  { value: 'support', label: 'Helper' },
+  { value: 'job_expected_exit', label: 'Finished job' },
+  { value: 'unknown', label: 'Unknown' },
+];
+
+const PORT_DOT_CLASS = {
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  red: 'bg-red-500',
+  gray: 'bg-gray-400',
+};
+
+function formatLatency(ms) {
+  if (ms == null || !Number.isFinite(ms)) return null;
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function Badge({ children, tone = 'slate' }) {
+  const tones = {
+    slate: 'bg-slate-100 text-slate-700 dark:bg-slate-700/40 dark:text-slate-300',
+    blue: 'bg-blue-100 text-blue-700 dark:bg-blue-800/30 dark:text-blue-300',
+    green: 'bg-green-100 text-green-700 dark:bg-green-800/30 dark:text-green-300',
+    red: 'bg-red-100 text-red-700 dark:bg-red-800/30 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-block px-1.5 py-0.5 text-[10px] font-medium rounded ${tones[tone] || tones.slate}`}>
+      {children}
+    </span>
+  );
+}
+
+function suppressedReasonLabel() {
+  return 'host-only';
+}
+
+function suppressedReasonTooltip(reason) {
+  switch (reason) {
+    case 'host-network':
+      return 'Bound to 127.0.0.1 on a host-network container, so it is reachable only from the machine running the container.';
+    case 'no-bridge-ip':
+      return 'Bound to 127.0.0.1 with no bridge route, so it is reachable only from the machine running the container.';
+    default:
+      return 'Bound to 127.0.0.1, so it is reachable only from the machine running the container.';
+  }
+}
+
+function PortRow({ port, status, displayCtx }) {
+  const proto = (port.protocol || 'tcp').toUpperCase();
+  const ip = displayCtx
+    ? getDisplayHost(port, displayCtx.serverId, displayCtx.serverUrl, displayCtx.hostOverride)
+    : (port.host_ip || '0.0.0.0');
+  const hp = port.host_port;
+  const target = port.target_port && String(port.target_port) !== String(hp) ? ` \u2192 ${port.target_port}` : '';
+  const color = status ? status.color : 'gray';
+  const suppressed = !!(status && status.suppressed);
+  const label = !status
+    ? 'checking'
+    : suppressed
+      ? suppressedReasonLabel()
+      : color === 'red'
+        ? 'unreachable'
+        : color === 'green'
+          ? 'reachable'
+          : color === 'yellow'
+            ? 'partial'
+            : 'unknown';
+  const dotClass = PORT_DOT_CLASS[color] || PORT_DOT_CLASS.gray;
+  const tooltip = suppressed
+    ? suppressedReasonTooltip(status.suppressedReason)
+    : (status && status.reason ? status.reason : undefined);
+  return (
+    <div className="flex items-center gap-2 py-1 pl-7 pr-3 text-xs" title={tooltip}>
+      <span className={`w-1.5 h-1.5 rounded-full ${dotClass} flex-shrink-0`} />
+      <span className="font-mono text-slate-700 dark:text-slate-200">
+        {ip}:{hp}
+      </span>
+      <span className="text-[10px] text-slate-400 dark:text-slate-500">{proto}{target}</span>
+      {port.internal ? <span className="text-[10px] text-slate-400 dark:text-slate-500">internal</span> : null}
+      <span className="ml-auto text-[10px] text-slate-500 dark:text-slate-400">{label}</span>
+    </div>
+  );
+}
+
+function computePortStats(ports, containerId, portStatuses) {
+  const myPorts = Array.isArray(ports) && containerId
+    ? ports.filter((p) => p && p.container_id === containerId)
+    : [];
+  const failingPortCount = myPorts.filter((p) => {
+    const st = portStatuses && portStatuses[`${p.host_ip}:${p.host_port}`];
+    return st && st.color === 'red' && !st.suppressed;
+  }).length;
+  const suppressedPortCount = myPorts.filter((p) => {
+    const st = portStatuses && portStatuses[`${p.host_ip}:${p.host_port}`];
+    return st && st.suppressed;
+  }).length;
+  return { myPorts, portCount: myPorts.length, failingPortCount, suppressedPortCount };
+}
+
+function RoleOverrideSelect({ value, component, onChangeRole }) {
+  return (
+    <label className="flex items-center gap-1.5 flex-shrink-0">
+      <span className="text-[10px] uppercase tracking-wide text-slate-400 dark:text-slate-500">Role</span>
+      <select
+        value={value}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChangeRole(component._serviceId, component.containerId, v === 'auto' ? null : v);
+        }}
+        onClick={(e) => e.stopPropagation()}
+        className="text-xs px-1.5 py-0.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        {ROLE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function ComponentRow({ component, onChangeRole, ports, portStatuses, displayCtx }) {
+  const [expanded, setExpanded] = useState(false);
+  const probe = component.probe || {};
+  const ok = probe.ok === true;
+  const err = probe.error;
+  const latency = formatLatency(probe.latencyMs);
+  const displayRole = component.effectiveRole || component.role;
+  const roleInfo = SIMPLE_ROLE[displayRole] || SIMPLE_ROLE.unknown;
+  const name = component._serviceName || 'component';
+  const short = component.containerId ? component.containerId.slice(0, 12) : null;
+  const explanation = component.reason || '';
+  const overridden = !!component.overridden;
+  const canOverride = !!(component.containerId && component._serviceId && onChangeRole);
+  const selectValue = overridden ? component.effectiveRole : 'auto';
+  const { myPorts, portCount, failingPortCount, suppressedPortCount } =
+    computePortStats(ports, component.containerId, portStatuses);
+
+  return (
+    <div className="border-t border-slate-200 dark:border-slate-700 first:border-t-0">
+      <div className="py-3 px-3">
+        <div className="flex items-center justify-between gap-2 mb-1.5">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="font-medium text-slate-900 dark:text-slate-100 truncate">{name}</span>
+            {short && (
+              <span className="text-[10px] font-mono text-slate-400 dark:text-slate-500">{short}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            <Badge tone={roleInfo.tone}>{roleInfo.label}</Badge>
+            {overridden && <Badge tone="blue">overridden</Badge>}
+            <Badge tone={ok ? 'green' : 'red'}>{ok ? 'reachable' : 'unreachable'}</Badge>
+          </div>
+        </div>
+        {explanation && (
+          <div className="text-xs text-slate-600 dark:text-slate-400 mb-1">
+            {explanation}
+          </div>
+        )}
+        <div className="flex items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <div className="flex items-center gap-2 min-w-0">
+            {latency && <span>{latency}</span>}
+            {!ok && err && (
+              <span className="truncate" title={err}>
+                {latency ? '· ' : ''}{err}
+              </span>
+            )}
+          </div>
+          {canOverride && (
+            <RoleOverrideSelect value={selectValue} component={component} onChangeRole={onChangeRole} />
+          )}
+        </div>
+        {portCount > 0 && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+            className="mt-2 flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+          >
+            {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+            <span>
+              {portCount} port{portCount === 1 ? '' : 's'}
+              {failingPortCount > 0 ? ` · ${failingPortCount} unreachable` : ''}
+              {suppressedPortCount > 0 ? ` · ${suppressedPortCount} host-only` : ''}
+            </span>
+          </button>
+        )}
+      </div>
+      {expanded && portCount > 0 && (
+        <div className="pb-2 bg-slate-50 dark:bg-slate-800/40 border-t border-slate-200 dark:border-slate-700">
+          {myPorts.map((p, i) => (
+            <PortRow
+              key={`${p.host_ip}:${p.host_port}:${p.protocol || 'tcp'}:${i}`}
+              port={p}
+              status={portStatuses && portStatuses[`${p.host_ip}:${p.host_port}`]}
+              displayCtx={displayCtx}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function summarize(components) {
+  const list = Array.isArray(components) ? components : [];
+  if (list.length === 0) return 'No component data available.';
+  const roleOf = (c) => c.effectiveRole || c.role;
+  const mains = list.filter((c) => roleOf(c) === 'core_access' || roleOf(c) === 'core_runtime');
+  const mainsOk = mains.filter((c) => c.probe && c.probe.ok === true);
+  if (mains.length === 0) {
+    return `No main component identified (${list.length} component${list.length === 1 ? '' : 's'}).`;
+  }
+  if (mainsOk.length === mains.length) {
+    return `All ${mains.length} main component${mains.length === 1 ? '' : 's'} reachable.`;
+  }
+  return `${mains.length - mainsOk.length} of ${mains.length} main component${mains.length === 1 ? '' : 's'} unreachable.`;
+}
+
+export function WhyThisStatusPopover({
+  open,
+  onOpenChange,
+  serviceName,
+  color,
+  components,
+  ports,
+  portStatuses,
+  updatedAt,
+  onRefresh,
+  serverId,
+  serverUrl,
+  hostOverride,
+}) {
+  const [refreshing, setRefreshing] = useState(false);
+  const { setOverride } = useOverrides();
+  const colorClass = COLOR_CLASSES[color] || COLOR_CLASSES.gray;
+  const componentCount = Array.isArray(components) ? components.length : 0;
+  const summary = summarize(components);
+  const displayCtx = { serverId, serverUrl, hostOverride };
+  const handleChangeRole = (serviceId, containerId, role) => {
+    setOverride(serviceId, containerId, role);
+  };
+
+  const handleRefresh = async (e) => {
+    if (e) { e.stopPropagation(); e.preventDefault(); }
+    if (!onRefresh || refreshing) return;
+    setRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const updatedLabel = updatedAt
+    ? `Updated ${Math.max(0, Math.round((Date.now() - updatedAt) / 1000))}s ago`
+    : 'Not yet updated';
+
+  const stop = (e) => e.stopPropagation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-lg"
+        onClick={stop}
+        onMouseDown={stop}
+        onMouseUp={stop}
+      >
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <span className={`w-2.5 h-2.5 rounded-full ${colorClass}`} />
+            <DialogTitle className="text-base">Why this status?</DialogTitle>
+          </div>
+          <DialogDescription className="pt-1 text-slate-600 dark:text-slate-400">
+            <span className="font-medium text-slate-800 dark:text-slate-200">{serviceName}</span>
+            <span className="mx-1.5 text-slate-400">·</span>
+            <span>{summary}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="border border-slate-200 dark:border-slate-700 rounded-md max-h-96 overflow-y-auto">
+          {componentCount === 0 ? (
+            <div className="p-4 text-sm text-slate-500 dark:text-slate-400 text-center">
+              No component detail available for this service.
+            </div>
+          ) : (
+            components.map((c, i) => (
+              <ComponentRow
+                key={(c.containerId || c.componentId || 'c') + ':' + i}
+                component={c}
+                onChangeRole={handleChangeRole}
+                ports={ports}
+                portStatuses={portStatuses}
+                displayCtx={displayCtx}
+              />
+            ))
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center justify-between sm:justify-between gap-2">
+          <span className="text-xs text-slate-500 dark:text-slate-400">{updatedLabel}</span>
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+            <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default WhyThisStatusPopover;

--- a/frontend/src/components/server/WhyThisStatusPopover.jsx
+++ b/frontend/src/components/server/WhyThisStatusPopover.jsx
@@ -62,11 +62,11 @@ function suppressedReasonLabel() {
 function suppressedReasonTooltip(reason) {
   switch (reason) {
     case 'host-network':
-      return 'Bound to 127.0.0.1 on a host-network container, so it is reachable only from the machine running the container.';
+      return 'Container uses host networking; 127.0.0.1 stays local.';
     case 'no-bridge-ip':
-      return 'Bound to 127.0.0.1 with no bridge route, so it is reachable only from the machine running the container.';
+      return 'No bridge IP available to route through.';
     default:
-      return 'Bound to 127.0.0.1, so it is reachable only from the machine running the container.';
+      return 'Bound to 127.0.0.1';
   }
 }
 

--- a/frontend/src/components/server/WhyThisStatusPopover.jsx
+++ b/frontend/src/components/server/WhyThisStatusPopover.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
-import { RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+import { RefreshCw, ChevronDown, ChevronRight, RotateCcw } from 'lucide-react';
 import { useOverrides } from '@/hooks/useOverrides';
 import { getDisplayHost } from './expanded-view-utils';
 import { humanizeProbeError } from '@/lib/health-copy';
@@ -275,6 +275,82 @@ function RoleLegend() {
   );
 }
 
+function ResetServiceRolesChip({ count, busy, confirming, onAskConfirm, onCancel, onConfirm }) {
+  if (confirming) {
+    return (
+      <div
+        role="group"
+        aria-label="Confirm reset roles"
+        className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/60 text-[10px] font-medium text-slate-700 dark:text-slate-200"
+      >
+        <span className="px-0.5">Reset {count}?</span>
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={(e) => { e.stopPropagation(); onCancel(); }}
+          disabled={busy}
+          className="px-1.5 py-0.5 rounded text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 disabled:opacity-50"
+        >
+          No
+        </button>
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={(e) => { e.stopPropagation(); onConfirm(); }}
+          disabled={busy}
+          className="px-1.5 py-0.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50"
+        >
+          {busy ? '\u2026' : 'Yes'}
+        </button>
+      </div>
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={(e) => { e.stopPropagation(); onAskConfirm(); }}
+          aria-label={`Reset ${count} customized role${count === 1 ? '' : 's'}`}
+          className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-blue-200 dark:border-blue-700/50 bg-blue-50 dark:bg-blue-900/30 text-[10px] font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50"
+        >
+          <RotateCcw className="w-3 h-3" />
+          <span className="tabular-nums">{count}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Reset {count} customized role{count === 1 ? '' : 's'} for this service</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function useServiceOverrideClear(components) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const { setOverride, clearAllForService } = useOverrides();
+  const serviceOverrideCount = Array.isArray(components)
+    ? components.filter((c) => c && c.overridden).length
+    : 0;
+  const serviceIdForClear = Array.isArray(components) && components.length > 0
+    ? (components.find((c) => c && c._serviceId) || {})._serviceId
+    : null;
+  const onConfirm = async () => {
+    if (!serviceIdForClear) return;
+    setBusy(true);
+    try {
+      await clearAllForService(serviceIdForClear);
+      setConfirming(false);
+    } finally { setBusy(false); }
+  };
+  return {
+    setOverride, serviceOverrideCount, serviceIdForClear,
+    confirming, busy,
+    onAskConfirm: () => setConfirming(true),
+    onCancel: () => setConfirming(false),
+    onConfirm,
+  };
+}
+
 export function WhyThisStatusPopover({
   open,
   onOpenChange,
@@ -290,30 +366,23 @@ export function WhyThisStatusPopover({
   hostOverride,
 }) {
   const [refreshing, setRefreshing] = useState(false);
-  const { setOverride } = useOverrides();
+  const ov = useServiceOverrideClear(components);
   const colorClass = COLOR_CLASSES[color] || COLOR_CLASSES.gray;
   const componentCount = Array.isArray(components) ? components.length : 0;
   const summary = summarize(components);
   const displayCtx = { serverId, serverUrl, hostOverride };
   const handleChangeRole = (serviceId, containerId, role) => {
-    setOverride(serviceId, containerId, role);
+    ov.setOverride(serviceId, containerId, role);
   };
-
   const handleRefresh = async (e) => {
     if (e) { e.stopPropagation(); e.preventDefault(); }
     if (!onRefresh || refreshing) return;
     setRefreshing(true);
-    try {
-      await onRefresh();
-    } finally {
-      setRefreshing(false);
-    }
+    try { await onRefresh(); } finally { setRefreshing(false); }
   };
-
   const updatedLabel = updatedAt
     ? `Updated ${Math.max(0, Math.round((Date.now() - updatedAt) / 1000))}s ago`
     : 'Not yet updated';
-
   const stop = (e) => e.stopPropagation();
 
   return (
@@ -328,6 +397,16 @@ export function WhyThisStatusPopover({
           <div className="flex items-center gap-2">
             <span className={`w-2.5 h-2.5 rounded-full ${colorClass}`} />
             <DialogTitle className="text-base">Why this status?</DialogTitle>
+            {ov.serviceOverrideCount > 0 && ov.serviceIdForClear && (
+              <ResetServiceRolesChip
+                count={ov.serviceOverrideCount}
+                busy={ov.busy}
+                confirming={ov.confirming}
+                onAskConfirm={ov.onAskConfirm}
+                onCancel={ov.onCancel}
+                onConfirm={ov.onConfirm}
+              />
+            )}
           </div>
           <DialogDescription className="pt-1 text-slate-600 dark:text-slate-400">
             <span className="font-medium text-slate-800 dark:text-slate-200">{serviceName}</span>
@@ -356,12 +435,14 @@ export function WhyThisStatusPopover({
           )}
         </div>
 
-        <DialogFooter className="flex items-center justify-between sm:justify-between gap-2">
-          <span className="text-xs text-slate-500 dark:text-slate-400">{updatedLabel}</span>
-          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
-            <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${refreshing ? 'animate-spin' : ''}`} />
-            Refresh
-          </Button>
+        <DialogFooter>
+          <div className="flex items-center justify-between gap-2 w-full">
+            <span className="text-xs text-slate-500 dark:text-slate-400">{updatedLabel}</span>
+            <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+              <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${refreshing ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/server/WhyThisStatusPopover.jsx
+++ b/frontend/src/components/server/WhyThisStatusPopover.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
 import { RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
 import { useOverrides } from '@/hooks/useOverrides';
 import { getDisplayHost } from './expanded-view-utils';
+import { humanizeProbeError } from '@/lib/health-copy';
 
 const COLOR_CLASSES = {
   green: 'bg-green-500',
@@ -13,16 +15,16 @@ const COLOR_CLASSES = {
 };
 
 const SIMPLE_ROLE = {
-  core_access: { label: 'main', tone: 'blue' },
-  core_runtime: { label: 'main', tone: 'blue' },
+  core_access: { label: 'main service', tone: 'blue' },
+  core_runtime: { label: 'main service', tone: 'blue' },
   support: { label: 'helper', tone: 'slate' },
   job_expected_exit: { label: 'finished', tone: 'slate' },
-  unknown: { label: 'unclear', tone: 'slate' },
+  unknown: { label: 'role unset', tone: 'slate' },
 };
 
 const ROLE_OPTIONS = [
   { value: 'auto', label: 'Auto (detect)' },
-  { value: 'core_runtime', label: 'Main' },
+  { value: 'core_runtime', label: 'Main service' },
   { value: 'support', label: 'Helper' },
   { value: 'job_expected_exit', label: 'Finished job' },
   { value: 'unknown', label: 'Unknown' },
@@ -186,7 +188,7 @@ function ComponentRow({ component, onChangeRole, ports, portStatuses, displayCtx
             {latency && <span>{latency}</span>}
             {!ok && err && (
               <span className="truncate" title={err}>
-                {latency ? '· ' : ''}{err}
+                {latency ? '· ' : ''}{humanizeProbeError(err)}
               </span>
             )}
           </div>
@@ -232,12 +234,45 @@ function summarize(components) {
   const mains = list.filter((c) => roleOf(c) === 'core_access' || roleOf(c) === 'core_runtime');
   const mainsOk = mains.filter((c) => c.probe && c.probe.ok === true);
   if (mains.length === 0) {
-    return `No main component identified (${list.length} component${list.length === 1 ? '' : 's'}).`;
+    return `No main service identified (${list.length} component${list.length === 1 ? '' : 's'} found).`;
   }
   if (mainsOk.length === mains.length) {
-    return `All ${mains.length} main component${mains.length === 1 ? '' : 's'} reachable.`;
+    return `All ${mains.length} main service${mains.length === 1 ? '' : 's'} reachable.`;
   }
-  return `${mains.length - mainsOk.length} of ${mains.length} main component${mains.length === 1 ? '' : 's'} unreachable.`;
+  return `${mains.length - mainsOk.length} of ${mains.length} main service${mains.length === 1 ? '' : 's'} unreachable.`;
+}
+
+const LEGEND_CHIP_CLASS = 'inline-flex items-baseline gap-1 px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-[11px] leading-snug';
+const LEGEND_TERM_CLASS = 'font-semibold text-slate-700 dark:text-slate-200';
+
+const LEGEND_ITEMS = [
+  { term: 'main service', desc: 'the app you connect to' },
+  { term: 'helper', desc: 'supporting piece (db, cache, worker)' },
+  { term: 'finished job', desc: 'one-shot setup task' },
+];
+
+function RoleLegend() {
+  return (
+    <div className="pt-2 space-y-2">
+      <TooltipProvider delayDuration={150}>
+        <div className="flex flex-wrap gap-1.5">
+          {LEGEND_ITEMS.map(({ term, desc }) => (
+            <Tooltip key={term}>
+              <TooltipTrigger asChild>
+                <span tabIndex={-1} className={LEGEND_CHIP_CLASS + ' cursor-help'}>
+                  <span className={LEGEND_TERM_CLASS}>{term}</span>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{desc}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </TooltipProvider>
+      <p className="text-[11px] leading-snug text-slate-500 dark:text-slate-400">
+        The dot reflects main services only. Hover a chip for its definition.
+      </p>
+    </div>
+  );
 }
 
 export function WhyThisStatusPopover({
@@ -299,12 +334,13 @@ export function WhyThisStatusPopover({
             <span className="mx-1.5 text-slate-400">·</span>
             <span>{summary}</span>
           </DialogDescription>
+          <RoleLegend />
         </DialogHeader>
 
         <div className="border border-slate-200 dark:border-slate-700 rounded-md max-h-96 overflow-y-auto">
           {componentCount === 0 ? (
             <div className="p-4 text-sm text-slate-500 dark:text-slate-400 text-center">
-              No component detail available for this service.
+              No component data available.
             </div>
           ) : (
             components.map((c, i) => (

--- a/frontend/src/components/server/compose-attribution.js
+++ b/frontend/src/components/server/compose-attribution.js
@@ -1,0 +1,11 @@
+export function inferComposeProjectFor(port, knownComposeProjects) {
+  if (port.compose_project || port.source !== "docker") return port.compose_project || null;
+  const owner = port.owner || "";
+  if (!/-\d+$/.test(owner)) return null;
+  return knownComposeProjects.find((project) => owner.startsWith(`${project}-`)) || null;
+}
+
+export function collectKnownComposeProjects(ports) {
+  return Array.from(new Set(ports.map((port) => port.compose_project).filter(Boolean)))
+    .sort((a, b) => b.length - a.length);
+}

--- a/frontend/src/components/server/expanded-view-utils.js
+++ b/frontend/src/components/server/expanded-view-utils.js
@@ -1,5 +1,8 @@
 export const getDisplayHost = (port, serverId, serverUrl, hostOverride) => {
-  if (port.host_ip === "0.0.0.0" || port.host_ip === "127.0.0.1") {
+  if (port.host_ip === "127.0.0.1") {
+    return "127.0.0.1";
+  }
+  if (port.host_ip === "0.0.0.0") {
     if (serverId === "local") {
       return hostOverride || window.location.hostname;
     } else if (serverUrl) {

--- a/frontend/src/components/server/service-card-utils.jsx
+++ b/frontend/src/components/server/service-card-utils.jsx
@@ -8,7 +8,10 @@ import {
 } from "@/components/ui/tooltip";
 
 export function getHostForPort(port, serverId, serverUrl, hostOverride) {
-  if (port.host_ip === "0.0.0.0" || port.host_ip === "127.0.0.1") {
+  if (port.host_ip === "127.0.0.1") {
+    return "127.0.0.1";
+  }
+  if (port.host_ip === "0.0.0.0") {
     if (serverId === "local") {
       return hostOverride || window.location.hostname;
     } else if (serverUrl) {

--- a/frontend/src/components/settings/ApiKeyModal.jsx
+++ b/frontend/src/components/settings/ApiKeyModal.jsx
@@ -216,7 +216,7 @@ export function ApiKeyModal({ isOpen, onClose }) {
                 ) : (
                   <div className="space-y-3">
                     <p className="text-sm text-slate-600 dark:text-slate-400">
-                      Generate an API key to allow other Portracker instances to scan this server.
+                      Generate an API key to allow other portracker instances to scan this server.
                     </p>
                     <Button onClick={generateKey} className="w-full" disabled={loading}>
                       {loading ? (

--- a/frontend/src/components/settings/SettingsModal.jsx
+++ b/frontend/src/components/settings/SettingsModal.jsx
@@ -33,6 +33,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useOverrides } from "@/hooks/useOverrides";
 
 const VERSION = "1.3.0";
 
@@ -74,6 +75,10 @@ export function SettingsModal({
   const [autoxposeUrl, setAutoxposeUrl] = useState("");
   const [autoxposeConnecting, setAutoxposeConnecting] = useState(false);
   const [autoxposeError, setAutoxposeError] = useState(null);
+  const { overrides, clearAll: clearAllOverrides } = useOverrides();
+  const overrideCount = overrides ? Object.keys(overrides).length : 0;
+  const [confirmClearOverrides, setConfirmClearOverrides] = useState(false);
+  const [clearingOverrides, setClearingOverrides] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -425,6 +430,60 @@ export function SettingsModal({
                     checked={localDisableCache}
                     onCheckedChange={handleCacheToggle}
                   />
+                </div>
+
+                <div className="flex items-center justify-between gap-3 pt-2 border-t border-slate-200 dark:border-slate-800">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm">Service role overrides</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info className="h-3.5 w-3.5 text-slate-400 cursor-help" />
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-[240px]">
+                        Roles you've manually changed for individual containers (Main / Helper / Finished job). Reset to let portracker auto-detect them again.
+                      </TooltipContent>
+                    </Tooltip>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">
+                      {overrideCount === 0 ? "none set" : overrideCount + " set"}
+                    </span>
+                  </div>
+                  {confirmClearOverrides ? (
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setConfirmClearOverrides(false)}
+                        disabled={clearingOverrides}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={clearingOverrides}
+                        onClick={async () => {
+                          setClearingOverrides(true);
+                          try {
+                            await clearAllOverrides();
+                          } finally {
+                            setClearingOverrides(false);
+                            setConfirmClearOverrides(false);
+                          }
+                        }}
+                      >
+                        {clearingOverrides ? "Clearing..." : "Confirm clear"}
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={overrideCount === 0}
+                      onClick={() => setConfirmClearOverrides(true)}
+                    >
+                      Clear all
+                    </Button>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/components/ui/ServiceIcon.jsx
+++ b/frontend/src/components/ui/ServiceIcon.jsx
@@ -4,6 +4,45 @@ import { getIconUrls } from '@/lib/service-icons';
 
 const urlIndexCache = new Map();
 
+const RESOLVED_LS_KEY = 'portracker.iconResolved.v1';
+const RESOLVED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function readResolvedCache() {
+  try {
+    const raw = localStorage.getItem(RESOLVED_LS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeResolvedCache(map) {
+  try {
+    localStorage.setItem(RESOLVED_LS_KEY, JSON.stringify(map));
+  } catch {
+  }
+}
+
+function getResolved(key) {
+  const map = readResolvedCache();
+  const entry = map[key];
+  if (!entry) return undefined;
+  if (typeof entry.t !== 'number' || Date.now() - entry.t > RESOLVED_TTL_MS) {
+    delete map[key];
+    writeResolvedCache(map);
+    return undefined;
+  }
+  return entry;
+}
+
+function setResolved(key, payload) {
+  const map = readResolvedCache();
+  map[key] = { ...payload, t: Date.now() };
+  writeResolvedCache(map);
+}
+
 function getCacheKey(name, isDark) {
   return `${name?.toLowerCase() || ''}:${isDark ? 'dark' : 'light'}`;
 }
@@ -13,8 +52,21 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
   const [needsInvert, setNeedsInvert] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const cacheKey = getCacheKey(name, isDark);
-  const [urlIndex, setUrlIndex] = useState(() => urlIndexCache.get(cacheKey) ?? 0);
+
+  const persistedRef = useRef(null);
+  if (persistedRef.current === null) {
+    persistedRef.current = getResolved(cacheKey) || false;
+  }
+  const persisted = persistedRef.current;
+
+  const initialIndex = (() => {
+    if (persisted && persisted.url === null) return -1;
+    return urlIndexCache.get(cacheKey) ?? 0;
+  })();
+
+  const [urlIndex, setUrlIndex] = useState(initialIndex);
   const imgRef = useRef(null);
+
   
   useEffect(() => {
     const observer = new MutationObserver(() => {
@@ -25,19 +77,28 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
   }, []);
   
   const urls = useMemo(() => {
+    if (persisted && persisted.url) {
+      return [{ url: persisted.url, isThemeVariant: !!persisted.themeVariant }];
+    }
     const serviceUrls = getIconUrls(name, isDark);
     if (source === 'docker' && name?.toLowerCase() !== 'docker') {
       return [...serviceUrls, ...getIconUrls('docker', isDark)];
     }
     return serviceUrls;
-  }, [name, isDark, source]);
+  }, [name, isDark, source, persisted]);
   const currentUrl = urls[urlIndex];
   const iconUrl = currentUrl?.url;
   const isThemeVariant = currentUrl?.isThemeVariant;
   
   useEffect(() => {
     const newCacheKey = getCacheKey(name, isDark);
-    setUrlIndex(urlIndexCache.get(newCacheKey) ?? 0);
+    const fresh = getResolved(newCacheKey);
+    persistedRef.current = fresh || false;
+    if (fresh && fresh.url === null) {
+      setUrlIndex(-1);
+    } else {
+      setUrlIndex(urlIndexCache.get(newCacheKey) ?? 0);
+    }
     setNeedsInvert(false);
     setIsLoaded(false);
   }, [isDark, name]);
@@ -49,6 +110,7 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
       setNeedsInvert(false);
       setIsLoaded(true);
       urlIndexCache.set(cacheKey, urlIndex);
+      setResolved(cacheKey, { url: iconUrl, themeVariant: true, invert: false });
       return;
     }
     
@@ -78,6 +140,7 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
         }
         setNeedsInvert(true);
         setIsLoaded(true);
+        setResolved(cacheKey, { url: iconUrl, themeVariant: false, invert: true });
       } else if (!isDark && avgBrightness > 200) {
         const nextVariantIdx = urls.findIndex((u, i) => i > urlIndex && u.isThemeVariant);
         if (nextVariantIdx !== -1) {
@@ -86,16 +149,18 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
         }
         setNeedsInvert(true);
         setIsLoaded(true);
+        setResolved(cacheKey, { url: iconUrl, themeVariant: false, invert: true });
       } else {
         setNeedsInvert(false);
         setIsLoaded(true);
         urlIndexCache.set(cacheKey, urlIndex);
+        setResolved(cacheKey, { url: iconUrl, themeVariant: false, invert: false });
       }
     } catch {
       setNeedsInvert(false);
       setIsLoaded(true);
     }
-  }, [cacheKey, isDark, isThemeVariant, urlIndex, urls]);
+  }, [cacheKey, iconUrl, isDark, isThemeVariant, urlIndex, urls]);
   
   const FallbackIcon = source === 'docker' ? Box : source === 'system' ? Cpu : Server;
   const containerClasses = `inline-flex items-center justify-center relative ${className}`;
@@ -107,6 +172,7 @@ function ServiceIconComponent({ name, source = 'docker', className = '', size = 
       setNeedsInvert(false);
       setIsLoaded(false);
     } else {
+      setResolved(cacheKey, { url: null });
       setUrlIndex(-1);
     }
   };

--- a/frontend/src/components/ui/WhatsNewModal.jsx
+++ b/frontend/src/components/ui/WhatsNewModal.jsx
@@ -330,10 +330,10 @@ export function WhatsNewModal({ isOpen, onClose, onDismiss, version, changes, gr
             </div>
             <div>
               <DialogTitle className="text-xl font-bold text-slate-900 dark:text-slate-100">
-                What's New in portracker {version}
+                What&apos;s New in portracker {version}
               </DialogTitle>
               <DialogDescription className="text-slate-600 dark:text-slate-400 mt-1">
-                Discover the latest features and improvements
+                A quick look at the changes you&apos;ll actually notice.
               </DialogDescription>
             </div>
           </div>
@@ -362,14 +362,14 @@ export function WhatsNewModal({ isOpen, onClose, onDismiss, version, changes, gr
             }}
             className="text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200"
           >
-            Don't show again
+            Don&apos;t auto-open again
           </Button>
           
           <Button
             onClick={onClose}
             className="min-w-[120px] bg-indigo-600 hover:bg-indigo-700 text-white dark:bg-indigo-500 dark:hover:bg-indigo-600 transition-colors duration-200"
           >
-            Get Started
+            Back to dashboard
           </Button>
         </div>
       </DialogContent>

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -2,9 +2,10 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }) {
+const Input = React.forwardRef(({ className, type, ...props }, ref) => {
   return (
     <input
+      ref={ref}
       type={type}
       data-slot="input"
       className={cn(
@@ -16,6 +17,8 @@ function Input({ className, type, ...props }) {
       {...props}
     />
   );
-}
+});
+
+Input.displayName = "Input";
 
 export { Input };

--- a/frontend/src/hooks/useOverrides.js
+++ b/frontend/src/hooks/useOverrides.js
@@ -1,0 +1,118 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'portracker.componentOverrides.v1';
+const VALID_ROLES = new Set(['core_runtime', 'core_access', 'support', 'job_expected_exit', 'unknown']);
+
+const OverridesContext = createContext(null);
+
+function makeKey(serviceId, containerId) {
+  if (!serviceId || !containerId) return null;
+  return String(serviceId) + '::' + String(containerId);
+}
+
+function readFromStorage() {
+  if (typeof window === 'undefined' || !window.localStorage) return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const out = {};
+    Object.keys(parsed).forEach((k) => {
+      const v = parsed[k];
+      if (typeof v === 'string' && VALID_ROLES.has(v)) out[k] = v;
+    });
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeToStorage(map) {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    return;
+  }
+}
+
+export function OverridesProvider({ children }) {
+  const [overrides, setOverrides] = useState(() => readFromStorage());
+
+  useEffect(() => {
+    writeToStorage(overrides);
+  }, [overrides]);
+
+  const getOverride = useCallback(
+    (serviceId, containerId) => {
+      const k = makeKey(serviceId, containerId);
+      if (!k) return null;
+      return overrides[k] || null;
+    },
+    [overrides]
+  );
+
+  const setOverride = useCallback((serviceId, containerId, role) => {
+    const k = makeKey(serviceId, containerId);
+    if (!k) return;
+    setOverrides((prev) => {
+      if (!role) {
+        if (!(k in prev)) return prev;
+        const next = { ...prev };
+        delete next[k];
+        return next;
+      }
+      if (!VALID_ROLES.has(role)) return prev;
+      if (prev[k] === role) return prev;
+      return { ...prev, [k]: role };
+    });
+  }, []);
+
+  const clearOverride = useCallback((serviceId, containerId) => {
+    setOverride(serviceId, containerId, null);
+  }, [setOverride]);
+
+  const clearAllForService = useCallback((serviceId) => {
+    if (!serviceId) return;
+    const prefix = String(serviceId) + '::';
+    setOverrides((prev) => {
+      const next = {};
+      let changed = false;
+      Object.keys(prev).forEach((k) => {
+        if (k.startsWith(prefix)) {
+          changed = true;
+          return;
+        }
+        next[k] = prev[k];
+      });
+      return changed ? next : prev;
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setOverrides((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+  }, []);
+
+  const value = useMemo(
+    () => ({ overrides, getOverride, setOverride, clearOverride, clearAllForService, clearAll }),
+    [overrides, getOverride, setOverride, clearOverride, clearAllForService, clearAll]
+  );
+
+  return React.createElement(OverridesContext.Provider, { value }, children);
+}
+
+export function useOverrides() {
+  const ctx = useContext(OverridesContext);
+  if (!ctx) {
+    return {
+      overrides: {},
+      getOverride: () => null,
+      setOverride: () => {},
+      clearOverride: () => {},
+      clearAllForService: () => {},
+      clearAll: () => {},
+    };
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/useOverrides.js
+++ b/frontend/src/hooks/useOverrides.js
@@ -1,13 +1,21 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 const STORAGE_KEY = 'portracker.componentOverrides.v1';
 const VALID_ROLES = new Set(['core_runtime', 'core_access', 'support', 'job_expected_exit', 'unknown']);
 
 const OverridesContext = createContext(null);
 
-function makeKey(serviceId, containerId) {
-  if (!serviceId || !containerId) return null;
-  return String(serviceId) + '::' + String(containerId);
+function normalizeFromStorage(raw) {
+  if (!raw || typeof raw !== 'object') return {};
+  const out = {};
+  Object.keys(raw).forEach((k) => {
+    const v = raw[k];
+    if (typeof v !== 'string' || !VALID_ROLES.has(v)) return;
+    const idx = k.indexOf('::');
+    const key = idx >= 0 ? k.slice(idx + 2) : k;
+    if (key) out[key] = v;
+  });
+  return out;
 }
 
 function readFromStorage() {
@@ -15,14 +23,7 @@ function readFromStorage() {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') return {};
-    const out = {};
-    Object.keys(parsed).forEach((k) => {
-      const v = parsed[k];
-      if (typeof v === 'string' && VALID_ROLES.has(v)) out[k] = v;
-    });
-    return out;
+    return normalizeFromStorage(JSON.parse(raw));
   } catch {
     return {};
   }
@@ -37,61 +38,99 @@ function writeToStorage(map) {
   }
 }
 
+async function fetchJsonOk(input, init) {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    const err = new Error('HTTP ' + res.status);
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
 export function OverridesProvider({ children }) {
   const [overrides, setOverrides] = useState(() => readFromStorage());
+  const overridesRef = useRef(overrides);
 
   useEffect(() => {
+    overridesRef.current = overrides;
     writeToStorage(overrides);
   }, [overrides]);
 
+  useEffect(() => {
+    let cancelled = false;
+    fetchJsonOk('/api/overrides', { credentials: 'include' })
+      .then((data) => {
+        if (cancelled) return;
+        const next = data && data.overrides && typeof data.overrides === 'object' ? data.overrides : {};
+        setOverrides(next);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
   const getOverride = useCallback(
-    (serviceId, containerId) => {
-      const k = makeKey(serviceId, containerId);
-      if (!k) return null;
-      return overrides[k] || null;
-    },
+    (_serviceId, containerId) => (containerId ? overrides[containerId] || null : null),
     [overrides]
   );
 
-  const setOverride = useCallback((serviceId, containerId, role) => {
-    const k = makeKey(serviceId, containerId);
-    if (!k) return;
-    setOverrides((prev) => {
-      if (!role) {
-        if (!(k in prev)) return prev;
-        const next = { ...prev };
-        delete next[k];
-        return next;
+  const setOverride = useCallback(async (serviceId, containerId, role) => {
+    if (!serviceId || !containerId) return;
+    if (role && !VALID_ROLES.has(role)) return;
+    const prev = overridesRef.current;
+    let next;
+    if (role) {
+      if (prev[containerId] === role) return;
+      next = { ...prev, [containerId]: role };
+    } else {
+      if (!(containerId in prev)) return;
+      next = { ...prev };
+      delete next[containerId];
+    }
+    setOverrides(next);
+    try {
+      const url = '/api/services/' + encodeURIComponent(serviceId) + '/components/' + encodeURIComponent(containerId) + '/role';
+      if (role) {
+        await fetchJsonOk(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ role }),
+        });
+      } else {
+        await fetchJsonOk(url, { method: 'DELETE', credentials: 'include' });
       }
-      if (!VALID_ROLES.has(role)) return prev;
-      if (prev[k] === role) return prev;
-      return { ...prev, [k]: role };
-    });
+    } catch {
+      setOverrides(prev);
+    }
   }, []);
 
-  const clearOverride = useCallback((serviceId, containerId) => {
-    setOverride(serviceId, containerId, null);
-  }, [setOverride]);
+  const clearOverride = useCallback((serviceId, containerId) => setOverride(serviceId, containerId, null), [setOverride]);
 
-  const clearAllForService = useCallback((serviceId) => {
+  const clearAllForService = useCallback(async (serviceId) => {
     if (!serviceId) return;
-    const prefix = String(serviceId) + '::';
-    setOverrides((prev) => {
-      const next = {};
-      let changed = false;
-      Object.keys(prev).forEach((k) => {
-        if (k.startsWith(prefix)) {
-          changed = true;
-          return;
-        }
-        next[k] = prev[k];
+    const prev = overridesRef.current;
+    try {
+      await fetchJsonOk('/api/services/' + encodeURIComponent(serviceId) + '/overrides', {
+        method: 'DELETE',
+        credentials: 'include',
       });
-      return changed ? next : prev;
-    });
+      const fresh = await fetchJsonOk('/api/overrides', { credentials: 'include' });
+      const map = fresh && fresh.overrides && typeof fresh.overrides === 'object' ? fresh.overrides : {};
+      setOverrides(map);
+    } catch {
+      setOverrides(prev);
+    }
   }, []);
 
-  const clearAll = useCallback(() => {
-    setOverrides((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+  const clearAll = useCallback(async () => {
+    const prev = overridesRef.current;
+    setOverrides({});
+    try {
+      await fetchJsonOk('/api/overrides', { method: 'DELETE', credentials: 'include' });
+    } catch {
+      setOverrides(prev);
+    }
   }, []);
 
   const value = useMemo(

--- a/frontend/src/hooks/useServiceHealth.js
+++ b/frontend/src/hooks/useServiceHealth.js
@@ -1,0 +1,252 @@
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useOverrides } from './useOverrides';
+
+const ServiceHealthContext = createContext(null);
+
+const ROLE_LABELS = {
+  core_access: 'core',
+  core_runtime: 'core',
+  support: 'support',
+  job_expected_exit: 'finished job',
+  unknown: 'unknown',
+};
+
+const RULE_LABELS = {
+  R1: 'container check',
+  R2: 'you set this',
+  R3: 'depended on',
+  R4: 'only port',
+  R5: 'loopback or UDP sibling',
+  R6: 'finished job',
+  R7: 'guessed from name',
+  R8: 'unknown',
+};
+
+const COLOR_SEVERITY = { green: 0, gray: 1, yellow: 2, red: 3 };
+
+function isCoreRole(role) {
+  return role === 'core_runtime' || role === 'core_access';
+}
+
+function recomputeServiceColor(originalColor, components) {
+  const list = Array.isArray(components) ? components : [];
+  if (list.length === 0) return originalColor || 'gray';
+  const cores = list.filter((c) => isCoreRole(c.effectiveRole || c.role));
+  if (cores.length === 0) return originalColor || 'gray';
+  const coreFailed = cores.some((c) => c.probe && c.probe.ok === false);
+  if (coreFailed) return 'red';
+  const supports = list.filter((c) => (c.effectiveRole || c.role) === 'support');
+  const supportFailed = supports.some((c) => c.probe && c.probe.ok === false);
+  if (supportFailed) return 'yellow';
+  const allCoreOk = cores.every((c) => c.probe && c.probe.ok === true);
+  return allCoreOk ? 'green' : (originalColor || 'gray');
+}
+
+function mergeColors(colors) {
+  let worst = 'green';
+  colors.forEach((c) => {
+    if ((COLOR_SEVERITY[c] || 0) > (COLOR_SEVERITY[worst] || 0)) worst = c;
+  });
+  return worst;
+}
+
+function buildIndex(services) {
+  const byProject = new Map();
+  const byContainer = new Map();
+  const byServiceName = new Map();
+  (services || []).forEach((svc) => {
+    const projectKey = svc.project || '__noproject__';
+    if (!byProject.has(projectKey)) byProject.set(projectKey, []);
+    byProject.get(projectKey).push(svc);
+    if (svc.name) {
+      if (!byServiceName.has(svc.name)) byServiceName.set(svc.name, []);
+      byServiceName.get(svc.name).push(svc);
+    }
+    (svc.components || []).forEach((comp) => {
+      if (comp.containerId) {
+        byContainer.set(comp.containerId, { service: svc, component: comp });
+        const short = comp.containerId.slice(0, 12);
+        if (!byContainer.has(short)) byContainer.set(short, { service: svc, component: comp });
+      }
+    });
+  });
+  return { byProject, byContainer, byServiceName };
+}
+
+function findServiceMatches({ index, isDocker, composeProject, serviceName, containerId, containerIds }) {
+  if (!isDocker) return [];
+  const uniqIds = Array.from(new Set(
+    (Array.isArray(containerIds) && containerIds.length ? containerIds : [containerId]).filter(Boolean)
+  ));
+  const matches = [];
+  const seen = new Set();
+  uniqIds.forEach((id) => {
+    const hit = index.byContainer.get(id) || index.byContainer.get(id.slice(0, 12));
+    if (hit && !seen.has(hit.service.serviceId)) {
+      seen.add(hit.service.serviceId);
+      matches.push(hit.service);
+    }
+  });
+  if (matches.length === 0 && composeProject) return index.byProject.get(composeProject) || [];
+  if (matches.length === 0 && serviceName) return index.byServiceName.get(serviceName) || [];
+  return matches;
+}
+
+function applyOverridesToMatches(matches, getOverride) {
+  const components = [];
+  const overrideAdjustedColors = new Map();
+  matches.forEach((svc) => {
+    let serviceHasOverride = false;
+    const svcComps = (svc.components || []).map((comp) => {
+      const ovRole = comp.containerId ? getOverride(svc.serviceId, comp.containerId) : null;
+      const overridden = !!ovRole;
+      if (overridden) serviceHasOverride = true;
+      return { ...comp, _serviceName: svc.name, _serviceId: svc.serviceId, effectiveRole: ovRole || comp.role, overridden };
+    });
+    svcComps.forEach((c) => components.push(c));
+    if (serviceHasOverride) {
+      overrideAdjustedColors.set(svc.serviceId, recomputeServiceColor(svc.color, svcComps));
+    }
+  });
+  return { components, overrideAdjustedColors };
+}
+
+function isAmbientGray(svc, effectiveColor) {
+  if (effectiveColor !== 'gray') return false;
+  const comps = svc.components || [];
+  if (comps.length === 0) return false;
+  return comps.every((c) => {
+    if (c.ruleId === 'R6') return true;
+    if (c.ruleId === 'R8' && c.probe && c.probe.ok === true) return true;
+    return false;
+  });
+}
+
+function describeMatches(matches, color, effectiveServiceColor) {
+  if (matches.length === 1) return matches[0].reason || null;
+  if (color === 'green') {
+    const greens = matches.filter((s) => effectiveServiceColor(s) === 'green');
+    const ambient = matches.length - greens.length;
+    const names = greens.slice(0, 3).map((s) => s.name || s.serviceId).join(', ');
+    const extraGreen = greens.length > 3 ? ` (+${greens.length - 3} more)` : '';
+    return ambient > 0
+      ? `${greens.length} main service${greens.length === 1 ? '' : 's'} reachable (${names}${extraGreen}); ${ambient} helper checked`
+      : `${greens.length} main service${greens.length === 1 ? '' : 's'} reachable: ${names}${extraGreen}`;
+  }
+  const worst = matches.filter((s) => effectiveServiceColor(s) === color);
+  const names = worst.slice(0, 3).map((s) => s.name || s.serviceId).join(', ');
+  const extra = worst.length > 3 ? ` (+${worst.length - 3} more)` : '';
+  const firstError = worst.flatMap((s) => s.components || [])
+    .map((c) => (c && c.probe && c.probe.error) || c.reason).find(Boolean) || null;
+  return `${color} via ${names}${extra}${firstError ? `: ${firstError}` : ''}`;
+}
+
+function buildLookupCard(state, index, getOverride) {
+  return (args) => {
+    if (!state.enabled) return null;
+    const matches = findServiceMatches({ index, ...args });
+    if (!matches.length) return null;
+    const { components, overrideAdjustedColors } = applyOverridesToMatches(matches, getOverride);
+    const effectiveServiceColor = (svc) =>
+      overrideAdjustedColors.has(svc.serviceId) ? overrideAdjustedColors.get(svc.serviceId) : svc.color;
+    const effective = matches.filter((m) => !isAmbientGray(m, effectiveServiceColor(m)));
+    const colorSource = effective.length > 0 ? effective : matches;
+    const color = mergeColors(colorSource.map(effectiveServiceColor).filter(Boolean));
+    const reason = describeMatches(matches, color, effectiveServiceColor);
+    return { color, reason, services: matches, components };
+  };
+}
+
+export function ServiceHealthProvider({ children, refreshMs = 15000 }) {
+  const [state, setState] = useState({ enabled: false, services: [], updatedAt: null, loading: true });
+  const disabledRef = useRef(false);
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const res = await fetch('/api/services', { credentials: 'include' });
+      if (res.status === 404) {
+        disabledRef.current = true;
+        setState({ enabled: false, services: [], updatedAt: null, loading: false });
+        return;
+      }
+      if (!res.ok) {
+        setState((prev) => ({ ...prev, loading: false }));
+        return;
+      }
+      const data = await res.json();
+      setState({
+        enabled: true,
+        services: Array.isArray(data.services) ? data.services : [],
+        updatedAt: Date.now(),
+        loading: false,
+      });
+    } catch {
+      setState((prev) => ({ ...prev, loading: false }));
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchOnce();
+  }, [fetchOnce]);
+
+  useEffect(() => {
+    if (disabledRef.current) return;
+    const id = setInterval(fetchOnce, refreshMs);
+    return () => clearInterval(id);
+  }, [fetchOnce, refreshMs]);
+
+  const index = useMemo(() => buildIndex(state.services), [state.services]);
+  const { getOverride } = useOverrides();
+
+  const value = useMemo(() => {
+    const lookupCard = buildLookupCard(state, index, getOverride);
+
+    const lookupPort = ({ container_id: containerId }) => {
+      if (!state.enabled || !containerId) return null;
+      const hit = index.byContainer.get(containerId) || index.byContainer.get(containerId.slice(0, 12));
+      if (!hit) return null;
+      return {
+        component: hit.component,
+        service: hit.service,
+      };
+    };
+
+    return {
+      enabled: state.enabled,
+      loading: state.loading,
+      updatedAt: state.updatedAt,
+      services: state.services,
+      refresh: fetchOnce,
+      lookupCard,
+      lookupPort,
+    };
+  }, [state, index, fetchOnce, getOverride]);
+
+  return React.createElement(ServiceHealthContext.Provider, { value }, children);
+}
+
+export function useServiceHealth() {
+  const ctx = useContext(ServiceHealthContext);
+  if (!ctx) {
+    return {
+      enabled: false,
+      loading: false,
+      updatedAt: null,
+      services: [],
+      refresh: () => {},
+      lookupCard: () => null,
+      lookupPort: () => null,
+    };
+  }
+  return ctx;
+}
+
+export function roleLabel(role) {
+  return ROLE_LABELS[role] || role || 'unknown';
+}
+
+export function ruleLabel(ruleId) {
+  return RULE_LABELS[ruleId] || ruleId || '';
+}
+
+export { ROLE_LABELS, RULE_LABELS };

--- a/frontend/src/lib/health-copy.js
+++ b/frontend/src/lib/health-copy.js
@@ -1,0 +1,21 @@
+export function humanizeProbeError(token) {
+  if (!token || typeof token !== 'string') return token || null;
+
+  if (token === 'timeout') return 'Connection timed out.';
+  if (token === 'healthcheck-unhealthy') return 'Container reports unhealthy.';
+  if (token === 'stale-completion') return 'Last finished too long ago to count as healthy.';
+  if (token === 'docker-api-unavailable') return "Can't reach Docker.";
+  if (token === 'inspect-failed') return "Couldn't inspect container.";
+  if (token === 'send-failed' || token === 'send-threw') return "Couldn't send UDP packet.";
+  if (token === 'no-valid-host-port') return 'No valid port to probe.';
+  if (token === 'missing-container-id') return 'Container info missing.';
+  if (token === 'unreachable') return 'Unreachable.';
+
+  const exit = token.match(/^exit-code-(-?\d+)$/);
+  if (exit) return `Exited with error (code ${exit[1]}).`;
+
+  const notExited = token.match(/^not-exited-(.+)$/);
+  if (notExited) return `Container is ${notExited[1]}, not finished.`;
+
+  return token;
+}

--- a/frontend/src/lib/hooks/useKeyboardShortcuts.js
+++ b/frontend/src/lib/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,52 @@
+import { useEffect, useCallback } from "react";
+
+export function useKeyboardShortcuts({
+  onFocusSearch,
+  onClearSearch,
+  onToggleSidebar,
+  onSelectServerByIndex,
+  onRefresh,
+}) {
+  const handleKeyDown = useCallback((event) => {
+    const isMod = event.metaKey || event.ctrlKey;
+    const tag = event.target.tagName;
+    const isInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || event.target.isContentEditable;
+
+    if (isMod && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      onFocusSearch?.();
+      return;
+    }
+
+    if (isMod && event.key.toLowerCase() === "b") {
+      event.preventDefault();
+      onToggleSidebar?.();
+      return;
+    }
+
+    if (isMod && event.key.toLowerCase() === "r" && !event.shiftKey) {
+      event.preventDefault();
+      onRefresh?.();
+      return;
+    }
+
+    if (event.key === "Escape" && isInput) {
+      onClearSearch?.();
+      event.target.blur();
+      return;
+    }
+
+    if (isInput) return;
+
+    if (event.key >= "1" && event.key <= "9" && !isMod && !event.shiftKey && !event.altKey) {
+      const index = parseInt(event.key, 10) - 1;
+      onSelectServerByIndex?.(index);
+      return;
+    }
+  }, [onFocusSearch, onClearSearch, onToggleSidebar, onSelectServerByIndex, onRefresh]);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/frontend/src/lib/hooks/useKonamiHackerMode.js
+++ b/frontend/src/lib/hooks/useKonamiHackerMode.js
@@ -1,0 +1,115 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const KONAMI_SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+const KONAMI_HINTS = ["↑", "Course input detected…", "gg, keyboard pilot."];
+const HACKER_MODE_KEY = "portracker_hacker_mode";
+
+export function useKonamiHackerMode({ pushHealthToast }) {
+  const [hackerMode, setHackerMode] = useState(() => {
+    try {
+      return localStorage.getItem(HACKER_MODE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const [konamiHint, setKonamiHint] = useState(null);
+  const progressRef = useRef(0);
+  const hintStageRef = useRef(0);
+  const hintTimeoutRef = useRef(null);
+
+  const showHint = useCallback((stage) => {
+    const index = Math.min(stage, KONAMI_HINTS.length - 1);
+    setKonamiHint(KONAMI_HINTS[index]);
+    if (hintTimeoutRef.current) {
+      clearTimeout(hintTimeoutRef.current);
+    }
+    hintTimeoutRef.current = setTimeout(() => setKonamiHint(null), 1200);
+  }, []);
+
+  useEffect(() => () => {
+    if (hintTimeoutRef.current) {
+      clearTimeout(hintTimeoutRef.current);
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setHackerMode((prev) => {
+      const next = !prev;
+      pushHealthToast({
+        type: "info",
+        message: next
+          ? "Hacker mode activated. Use Ctrl+Shift+H to toggle."
+          : "Hacker mode disabled.",
+      });
+      return next;
+    });
+    hintStageRef.current = 0;
+    progressRef.current = 0;
+  }, [pushHealthToast]);
+
+  const disable = useCallback(() => {
+    setHackerMode((prev) => {
+      if (!prev) return prev;
+      pushHealthToast({ type: "info", message: "Hacker mode disabled." });
+      return false;
+    });
+    hintStageRef.current = 0;
+    progressRef.current = 0;
+  }, [pushHealthToast]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(HACKER_MODE_KEY, hackerMode ? "true" : "false");
+    } catch {
+      void 0;
+    }
+    if (typeof document !== "undefined") {
+      document.body.classList.toggle("hacker-mode", hackerMode);
+    }
+  }, [hackerMode]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const handler = (event) => {
+      if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === "h") {
+        event.preventDefault();
+        toggle();
+        return;
+      }
+      if (event.key === "ArrowUp" && progressRef.current === 0) {
+        const stage = hintStageRef.current;
+        if (stage < KONAMI_HINTS.length) {
+          showHint(stage);
+          hintStageRef.current = stage + 1;
+        }
+      }
+      const normalized = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      const expected = KONAMI_SEQUENCE[progressRef.current];
+      if (normalized === expected) {
+        progressRef.current += 1;
+        if (progressRef.current === KONAMI_SEQUENCE.length) {
+          progressRef.current = 0;
+          toggle();
+        }
+        return;
+      }
+      progressRef.current = normalized === KONAMI_SEQUENCE[0] ? 1 : 0;
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [showHint, toggle]);
+
+  return { hackerMode, konamiHint, toggleHackerMode: toggle, disableHackerMode: disable };
+}

--- a/frontend/src/lib/hooks/useSidebarLayout.js
+++ b/frontend/src/lib/hooks/useSidebarLayout.js
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback } from "react";
+
+const DEFAULT_SIDEBAR_WIDTH = 360;
+const SIDEBAR_DISCOVERY_KEY = "portracker_sidebar_discovery_seen";
+const SIDEBAR_COLLAPSED_KEY = "sidebarCollapsed";
+const SIDEBAR_WIDTH_KEY = "sidebarWidth";
+
+function readBool(key, fallback = false) {
+  try {
+    return localStorage.getItem(key) === "true";
+  } catch {
+    return fallback;
+  }
+}
+
+function readWidth() {
+  try {
+    const saved = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    return saved ? parseInt(saved, 10) : DEFAULT_SIDEBAR_WIDTH;
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH;
+  }
+}
+
+export function useSidebarLayout({
+  pushHealthToast,
+  isWhatsNewOpen,
+  loading,
+  groupCount,
+  logger,
+}) {
+  const [isCollapsed, setCollapsed] = useState(() => readBool(SIDEBAR_COLLAPSED_KEY));
+  const [width, setWidth] = useState(readWidth);
+  const [requestedMode, setRequestedMode] = useState(null);
+  const [discoverySeen, setDiscoverySeen] = useState(() => readBool(SIDEBAR_DISCOVERY_KEY));
+  const [discoveryVisible, setDiscoveryVisible] = useState(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState({});
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, isCollapsed ? "true" : "false");
+    } catch {
+      void 0;
+    }
+  }, [isCollapsed]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+    } catch (error) {
+      logger?.warn?.("Failed to save sidebar width:", error);
+    }
+  }, [width, logger]);
+
+  const markDiscoverySeen = useCallback(() => {
+    setDiscoverySeen(true);
+    setDiscoveryVisible(false);
+    try {
+      localStorage.setItem(SIDEBAR_DISCOVERY_KEY, "true");
+    } catch {
+      void 0;
+    }
+  }, []);
+
+  const onCollapseToggle = useCallback(() => {
+    setCollapsed((prev) => !prev);
+    markDiscoverySeen();
+  }, [markDiscoverySeen]);
+
+  const onWidthChange = useCallback((nextWidth) => {
+    setWidth(nextWidth);
+    if (Math.abs(nextWidth - DEFAULT_SIDEBAR_WIDTH) > 8) markDiscoverySeen();
+  }, [markDiscoverySeen]);
+
+  const onDiscoveryDismiss = useCallback((dontShowAgain) => {
+    setDiscoveryVisible(false);
+    if (dontShowAgain) markDiscoverySeen();
+  }, [markDiscoverySeen]);
+
+  const onDiscoveryTry = useCallback(() => onCollapseToggle(), [onCollapseToggle]);
+
+  const onOpenAddServer = useCallback(() => {
+    setCollapsed(false);
+    setRequestedMode("add");
+    markDiscoverySeen();
+  }, [markDiscoverySeen]);
+
+  const onSidebarMaxedOut = useCallback(() => {
+    pushHealthToast?.({ type: "info", message: "Sidebar maxed. Hope you have ports." });
+  }, [pushHealthToast]);
+
+  const onRequestedModeHandled = useCallback(() => setRequestedMode(null), []);
+
+  const stampRefreshed = useCallback((items) => {
+    setLastRefreshedAt((prev) => {
+      const now = Date.now();
+      const next = { ...prev };
+      items.forEach((s) => { next[s.id] = now; });
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (discoverySeen || loading || !groupCount || isCollapsed || isWhatsNewOpen) {
+      setDiscoveryVisible(false);
+      return undefined;
+    }
+    if (typeof window !== "undefined" && window.innerWidth < 1024) {
+      return undefined;
+    }
+    const timer = setTimeout(() => setDiscoveryVisible(true), 2200);
+    return () => clearTimeout(timer);
+  }, [discoverySeen, loading, groupCount, isCollapsed, isWhatsNewOpen]);
+
+  return {
+    isCollapsed,
+    width,
+    requestedMode,
+    discoveryVisible,
+    lastRefreshedAt,
+    stampRefreshed,
+    onCollapseToggle,
+    onWidthChange,
+    onDiscoveryDismiss,
+    onDiscoveryTry,
+    onOpenAddServer,
+    onSidebarMaxedOut,
+    onRequestedModeHandled,
+  };
+}

--- a/frontend/src/lib/hooks/useWhatsNew.js
+++ b/frontend/src/lib/hooks/useWhatsNew.js
@@ -34,25 +34,7 @@ export function useWhatsNew() {
 
   const handleShow = useCallback(() => {
     setIsModalOpen(true);
-    
-    const hasExistingData = newVersions.length > 0 && whatsNewData[newVersions[0]];
-    
-    if (!hasExistingData && currentVersion) {
-      const testChanges = {
-        frontend: [
-          { title: 'Container Details Drawer', description: 'New slide-out panel to show detailed information for Docker containers including stats, labels, mounts, and environment variables' },
-          { title: 'Internal Port Display', description: 'UI now correctly shows and differentiates internal-only ports from published ports with health status monitoring' },
-          { title: 'Global Search', description: 'Search bar now includes an option to search across all servers simultaneously' },
-          { title: "What's New Modal", description: 'Automatic notification system to stay updated with new features when opening new versions' }
-        ],
-        backend: [
-          { title: 'Collector Caching', description: 'Added caching mechanism to all data collectors to reduce duplicate requests and improve data refresh speed' }
-        ]
-      };
-      setWhatsNewData(prev => ({ ...prev, [currentVersion]: testChanges }));
-      setNewVersions([currentVersion]);
-    }
-  }, [whatsNewData, newVersions, currentVersion]);
+  }, []);
 
   const handleDismiss = useCallback(() => {
     try {
@@ -137,7 +119,9 @@ export function useWhatsNew() {
               isDismissed
             });
             
-            if (!isDismissed) {
+            const shouldAutoOpen = !isDismissed && !!lastSeenVersion;
+
+            if (shouldAutoOpen) {
               logger.debug('Opening What\'s New modal');
               setTimeout(() => {
                 setIsModalOpen(true);

--- a/frontend/src/lib/whats-new-config.js
+++ b/frontend/src/lib/whats-new-config.js
@@ -1,7 +1,188 @@
 const whatsNewConfig = {
   combineWhatsNewGroups: [
     { versions: ['1.3.1', '1.3.2', '1.3.3', '1.3.4'], mergeTitles: ['Duplicate Ports'] }
-  ]
+  ],
+  ignoreVersions: ['Unreleased'],
+  maxVersionsOnFirstOpen: 1,
+  hiddenTitles: [
+    'Frontend Error Logging',
+    'CI',
+    'npm Vulnerabilities',
+    'Remove Vulnerable SQLite System Packages',
+    'Port Dedup Key Consistency',
+    'TrueNAS WebSocket Base Handling',
+    'TrueNAS API Key Revocation',
+    'Debug Logging',
+    'Internal / Port display fixes',
+    'Port protocol reporting',
+    'Batch rename migration fix',
+    'Misc.',
+    'System Port Name Fix',
+    'Consistent Status Indicators',
+    'Dockerode Integration',
+    'Centralized Logging',
+    'Security Hardening',
+    'Data Collection',
+    'Docker Integration',
+    'Web Interface',
+    'Server Management',
+    'Server Health Indicator',
+    'Last Refreshed Timestamp'
+  ],
+  featureOverrides: {
+    'Container Heuristic': {
+      title: 'Better service naming in stack deployments',
+      description: 'Reduced false matches when containers share the same stack name.'
+    },
+    'Swarm Fallback Icon': {
+      title: 'Better Docker service icons',
+      description: 'Swarm services keep a recognizable Docker icon when the remote icon lookup fails.'
+    },
+    'Swarm Ingress Support': {
+      title: 'Docker Swarm ingress ports group correctly',
+      description: 'Ingress-mode published ports now stay attached to the right Docker service instead of falling back to system ports.'
+    },
+    'TrueNAS API Key Transport Security': {
+      title: 'Safer TrueNAS API key transport',
+      description: 'TrueNAS API key connections now stay on secure WebSocket endpoints.'
+    },
+    'Host-Network Service Deduplication': {
+      title: 'No more duplicate host-network services',
+      description: 'Services using host networking no longer show up twice when discovered through multiple paths.'
+    },
+    'Service Port Rendering': {
+      title: 'Cleaner service port chips',
+      description: 'Services no longer show repeated port chips when entries share the same host port.'
+    },
+    'Database Schema': {
+      title: 'Fresh installs work again',
+      description: 'Fixed a missing column that broke brand-new installs on first launch.'
+    },
+    'API Key Authentication': {
+      title: 'Secure peer-to-peer between instances',
+      description: 'Generate API keys in Settings to securely connect portracker instances.'
+    },
+    'Endpoint Protection': {
+      title: 'Endpoints protected when auth is on',
+      description: 'All data endpoints now require auth when authentication is enabled.'
+    },
+    'autoxpose Integration': {
+      title: "See what's exposed publicly",
+      description: 'Connect an autoxpose instance in Settings to see public URLs next to your internal ports.'
+    },
+    'Settings Modal': {
+      title: 'One place for settings',
+      description: 'Theme, refresh interval, autoxpose connection, and advanced options live in a single modal.'
+    },
+    'Reverse Proxy Support': {
+      title: 'Works behind a reverse proxy',
+      description: 'Set HOST_OVERRIDE to control the hostname used in port links.'
+    },
+    'System Port Detection': {
+      title: 'System ports detected in containers',
+      description: 'Restored SSH, SMB, and other system port detection inside containerized deployments.'
+    },
+    'Service-Centric View': {
+      title: 'Ports grouped by service',
+      description: 'Ports are now grouped by service in expandable cards. This is the default view.'
+    },
+    'Service Icons': {
+      title: 'Service icons, theme-aware',
+      description: 'Known services show icons that adapt to light and dark mode.'
+    },
+    'Collapsed Health Status': {
+      title: 'Health at a glance when collapsed',
+      description: 'Collapsed service cards now show an aggregated health indicator.'
+    },
+    'Favicon': {
+      title: 'Favicon follows your theme',
+      description: 'The favicon now adapts to light and dark system themes.'
+    },
+    'TrueNAS Integration': {
+      title: 'Faster, more reliable TrueNAS',
+      description: 'Parallel API calls, per-call timeouts, and reused connections make TrueNAS collection steadier.'
+    },
+    'TrueNAS Enhanced Features': {
+      title: 'TrueNAS VMs and LXCs from the UI',
+      description: 'Add a TrueNAS API key from Settings to see VM and LXC containers in your dashboard.'
+    },
+    'Authentication': {
+      title: 'Optional dashboard login',
+      description: 'Turn on ENABLE_AUTH to protect the dashboard. Off by default.'
+    },
+    'Auto-Refresh': {
+      title: 'Auto-refresh every 30s',
+      description: 'Toggle auto-refresh from the header to keep ports and services live.'
+    },
+    'Random Port Generator': {
+      title: 'Pick an unused port',
+      description: "One click to generate a port that isn't already taken."
+    },
+    'Virtual Machines & Containers': {
+      title: 'VMs and LXCs look right',
+      description: 'VMs and LXC containers now show correct icons and badges.'
+    },
+    'Service renaming': {
+      title: 'Rename services from the UI',
+      description: 'You can rename services directly in the dashboard.'
+    },
+    'Batch actions': {
+      title: 'Bulk actions on ports',
+      description: 'Select multiple services or ports to ignore or annotate them at once.'
+    },
+    'Container Details Drawer': {
+      title: 'Container details drawer',
+      description: 'Slide-out panel with stats, labels, mounts, and env vars for Docker containers.'
+    },
+    'Internal Port Display': {
+      title: 'Internal vs published ports, clear',
+      description: 'Internal-only ports are now clearly distinguished from published ones, with health status.'
+    },
+    'Global Search': {
+      title: 'Search across all servers',
+      description: 'The search bar can search every connected server at once.'
+    },
+    "What's New": {
+      title: 'Release notes modal',
+      description: 'portracker tells you what changed when you open a new version.'
+    },
+    'Collector Caching': {
+      title: 'Faster refreshes',
+      description: 'Data collectors now cache between refreshes to reduce duplicate work.'
+    },
+    'Enhanced Service Detection': {
+      title: 'Better service detection',
+      description: 'Improved identification and categorization of running services, including SPA apps.'
+    },
+    'Port Status Indicators': {
+      title: 'Clearer port status',
+      description: 'Visual distinction between published and internal ports, with detailed status.'
+    },
+    'Removed network_mode: host Requirement': {
+      title: 'No host networking required',
+      description: 'Direct /proc parsing replaces the need for Docker host networking mode.'
+    },
+    'Advanced Port Detection': {
+      title: 'More accurate port detection',
+      description: 'Multiple detection methods improve container and system port identification.'
+    },
+    'Improved Container Introspection': {
+      title: 'Steadier container collection',
+      description: 'Better error handling and fallbacks across platforms for reliable port collection.'
+    },
+    'Simplified Docker Dependencies': {
+      title: 'Simpler Docker setup',
+      description: 'No extra system socket mounts required, and Docker proxy is supported.'
+    },
+    'Enhanced Data Accuracy': {
+      title: 'More accurate container metadata',
+      description: 'Timestamps and metadata parsing are more precise.'
+    },
+    'Multi-platform Port Tracking': {
+      title: 'portracker is out',
+      description: 'Monitor ports across multiple servers from one dashboard.'
+    }
+  }
 };
 
 export default whatsNewConfig;

--- a/frontend/src/lib/whats-new.js
+++ b/frontend/src/lib/whats-new.js
@@ -1,4 +1,5 @@
 import Logger from './logger';
+import whatsNewConfig from './whats-new-config';
 
 const logger = new Logger('WhatsNewUtils');
 
@@ -14,11 +15,71 @@ const CATEGORY_KEYS = [
   'misc'
 ];
 
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
 function createFeatureBuckets() {
   return CATEGORY_KEYS.reduce((acc, key) => {
     acc[key] = [];
     return acc;
   }, { highlights: [] });
+}
+
+function cleanInlineFormatting(value = '') {
+  return value
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeFeatureTitle(value = '') {
+  return cleanInlineFormatting(value)
+    .replace(/^\[(.+)\]$/, '$1')
+    .replace(/^\[sub\]\s*/i, '')
+    .trim();
+}
+
+function normalizeFeatureDescription(value = '') {
+  return cleanInlineFormatting(value)
+    .replace(/\s*\((?:resolves|addresses)?\s*#\d+\)/gi, '')
+    .replace(/\s*\(#\d+(?:\s*,\s*PR\s*#\d+)?(?:\s+by\s+@[^)]+)?\)/gi, '')
+    .replace(/\s+[-–—]\s+$/, '')
+    .trim();
+}
+
+function shouldIgnoreVersion(version) {
+  const ignoredVersions = Array.isArray(whatsNewConfig.ignoreVersions)
+    ? whatsNewConfig.ignoreVersions
+    : [];
+
+  return ignoredVersions.includes(version) || !SEMVER_PATTERN.test(version);
+}
+
+function applyFeatureOverrides(feature) {
+  const hiddenTitles = new Set((whatsNewConfig.hiddenTitles || []).map((title) => title.toLowerCase()));
+  const normalizedTitle = normalizeFeatureTitle(feature.title);
+
+  if (hiddenTitles.has(normalizedTitle.toLowerCase())) {
+    return null;
+  }
+
+  const override = whatsNewConfig.featureOverrides?.[normalizedTitle];
+  if (override?.hidden) {
+    return null;
+  }
+
+  return {
+    ...feature,
+    title: override?.title || normalizedTitle,
+    description: override?.description || normalizeFeatureDescription(feature.description),
+    details: Array.isArray(feature.details)
+      ? feature.details
+          .map((detail) => ({
+            title: normalizeFeatureTitle(detail.title || ''),
+            description: normalizeFeatureDescription(detail.description || ''),
+          }))
+          .filter((detail) => detail.title || detail.description)
+      : [],
+  };
 }
 
 const CATEGORY_MAPPINGS = [
@@ -85,6 +146,12 @@ export function parseChangelog(changelogContent) {
         }
         
         currentVersion = versionMatch[1];
+        if (shouldIgnoreVersion(currentVersion)) {
+          currentSection = null;
+          features = createFeatureBuckets();
+          lastFeature = null;
+          continue;
+        }
         currentSection = null;
         features = createFeatureBuckets();
         lastFeature = null;
@@ -112,14 +179,18 @@ export function parseChangelog(changelogContent) {
           }
           lastFeature.details.push({ title: cleanTitle, description });
         } else {
-          const feature = {
+          const nextFeature = applyFeatureOverrides({
             title: isSubItem ? title.replace(/^\[sub\]\s*/, '').trim() : title,
             description,
             details: []
-          };
+          });
           
-          features[currentSection].push(feature);
-          lastFeature = feature;
+          if (nextFeature) {
+            features[currentSection].push(nextFeature);
+            lastFeature = nextFeature;
+          } else {
+            lastFeature = null;
+          }
         }
         continue;
       }
@@ -130,7 +201,7 @@ export function parseChangelog(changelogContent) {
         if (!lastFeature.details) {
           lastFeature.details = [];
         }
-        lastFeature.details.push({ title: '', description: text });
+        lastFeature.details.push({ title: '', description: normalizeFeatureDescription(text) });
       }
     }
 
@@ -204,8 +275,10 @@ export function getNewVersions(parsedVersions, lastSeenVersion) {
   logger.debug('getNewVersions: Available versions sorted:', availableVersions);
   
   if (!lastSeenVersion) {
-    logger.debug('getNewVersions: No last seen version, returning all versions:', availableVersions);
-    return availableVersions;
+    const maxVersionsOnFirstOpen = Math.max(1, whatsNewConfig.maxVersionsOnFirstOpen || 1);
+    const initialVersions = availableVersions.slice(0, maxVersionsOnFirstOpen);
+    logger.debug('getNewVersions: No last seen version, returning newest versions only:', initialVersions);
+    return initialVersions;
   }
   
   const newVersions = availableVersions.filter(version => {
@@ -221,7 +294,7 @@ export function getNewVersions(parsedVersions, lastSeenVersion) {
 export function combineVersionChanges(versions, versionKeys) {
   const combined = createFeatureBuckets();
   
-  const sortedVersions = versionKeys.sort((a, b) => compareVersions(b, a));
+  const sortedVersions = [...versionKeys].sort((a, b) => compareVersions(b, a));
   
   for (const version of sortedVersions) {
     const versionChanges = versions[version];
@@ -241,7 +314,7 @@ export function combineVersionChanges(versions, versionKeys) {
 }
 
 export function groupVersionChanges(versions, versionKeys) {
-  const sortedVersions = versionKeys.sort((a, b) => compareVersions(b, a));
+  const sortedVersions = [...versionKeys].sort((a, b) => compareVersions(b, a));
   
   return sortedVersions.map(version => {
     const versionChanges = versions[version];


### PR DESCRIPTION
## Summary

Smarter service status indicator with per-port evidence and per-component overrides, plus sidebar UX improvements.

### Backend
- **Protocol-Aware Probes**: HTTP / HTTPS / TCP / UDP / container-state / job-completion instead of HTTP-only. UDP services and successfully-exited jobs no longer false-red (resolves #88).
- **Signal-Based Classifier**: Components auto-classified as `main` / `helper` / `finished job` / `unknown` using rules over Docker and compose data.
- **Service-Level Aggregation**: A failing `helper` degrades to yellow while `main` stays healthy, instead of the whole service going red.
- **Bridge-IP Rescue**: Ports bound to the docker bridge IP (e.g. `172.17.0.x`) are probed there as a fallback.
- **Component Role Overrides**: New `component_overrides` table and `/api/overrides` endpoints persist overrides server-side.

### Frontend
- **"Why This Status" Popover**: Per-service panel showing the failing component, the rule that fired, and per-port evidence (host:port, protocol, reachability).
- **Component Role Overrides**: `Auto` / `Main` / `Helper` / `Finished job` / `Unknown` picker per component, takes precedence over auto-classification.
- **Settings → Advanced**: "Service role overrides" section with a 2-step "Clear all" action.
- **Sidebar**: Collapsible and resizable, with a discovery nudge and keyboard shortcuts (resolves #97).
- **What's New Modal**: Curated entries so only user-facing changes show after a release.
