### PR TITLE
feat: drag-and-drop sidebar reordering with custom and alphabetical v…

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const Database = require("better-sqlite3");
 const { Logger } = require("./lib/logger");
+const { migrateServersInPlace } = require("./lib/db/servers-migrations");
 
 const logger = new Logger("Database", { debug: process.env.DEBUG === 'true' });
 
@@ -37,6 +38,7 @@ if (!tableExists) {
       api_key TEXT,
       api_key_created_at TEXT,
       remote_api_key TEXT,
+      position INTEGER,
       FOREIGN KEY (parentId) REFERENCES servers(id)
     );
     
@@ -177,26 +179,7 @@ if (!tableExists) {
         'Database schema migration for "type" column completed successfully'
       );
     } else {
-      if (!columnNames.includes("platform")) {
-        logger.info("Migrating database: Adding platform column to servers table");
-        db.prepare(
-          "ALTER TABLE servers ADD COLUMN platform TEXT DEFAULT 'standard'"
-        ).run();
-      }
-      if (!columnNames.includes("platform_config")) {
-        logger.info(
-          "Migrating database: Adding platform_config column to servers table"
-        );
-        db.prepare("ALTER TABLE servers ADD COLUMN platform_config TEXT").run();
-      }
-      if (!columnNames.includes("platform_type")) {
-        logger.info(
-          "Migrating database: Adding platform_type column to servers table"
-        );
-        db.prepare(
-          "ALTER TABLE servers ADD COLUMN platform_type TEXT DEFAULT 'auto'"
-        ).run();
-      }
+      migrateServersInPlace(db, logger, columnNames);
     }
 
     const customServiceNamesTableExists = db

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ const { requireAuth, requireAuthOrApiKey, checkAuthEnabled, isAuthEnabled } = re
 const authRoutes = require('./routes/auth');
 const settingsRoutes = require('./routes/settings');
 const autoxposeRoutes = require('./routes/autoxpose');
+const { registerServerRoutes } = require('./routes/servers');
 const recoveryManager = require('./lib/recovery-manager');
 const { enrichComposeLabelsOnPorts: enrichComposeLabelsOnPortsImpl } = require('./lib/docker/compose-attribution');
 
@@ -595,6 +596,7 @@ app.use(checkAuthEnabled);
 app.use('/api/auth', authRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/autoxpose', autoxposeRoutes);
+registerServerRoutes(app, { db, logger, requireAuth, validateServerInput });
 
 const PORT = process.env.PORT || 3000;
 
@@ -669,7 +671,11 @@ app.get("/api/all-ports", requireAuthOrApiKey, async (req, res) => {
   logger.debug(`GET /api/all-ports called with debug=${debug}`);
   
   try {
-    const servers = db.prepare("SELECT * FROM servers").all();
+    const servers = db
+      .prepare(
+        "SELECT * FROM servers ORDER BY (position IS NULL) ASC, position ASC, label COLLATE NOCASE ASC"
+      )
+      .all();
 
     const results = servers.map((s) => ({
       id: s.id,
@@ -1528,119 +1534,6 @@ function validateCustomServiceNameDeleteInput(req, res, next) {
 
   next();
 }
-
-app.get("/api/servers", requireAuth, (req, res) => {
-  logger.debug("GET /api/servers");
-  try {
-    const stmt = db.prepare(
-      "SELECT id, label, url, parentId, type, unreachable, platform_type, (remote_api_key IS NOT NULL) as hasApiKey FROM servers"
-    );
-    const servers = stmt.all();
-    logger.debug(`Returning ${servers.length} servers`);
-    res.json(servers);
-  } catch (error) {
-    logger.error("Failed to get servers:", error.message);
-    logger.debug("Stack trace:", error.stack || "");
-    res
-      .status(500)
-      .json({ error: "Failed to retrieve servers", details: error.message });
-  }
-});
-
-app.post("/api/servers", requireAuth, validateServerInput, (req, res) => {
-  const { id, label, url, parentId, type, unreachable, platform_type, apiKey } =
-    req.body;
-
-  if (!id) {
-    return res.status(400).json({ error: "Field 'id' is required" });
-  }
-
-  if (type === "peer" && !unreachable && (!url || url.trim().length === 0)) {
-    return res
-      .status(400)
-      .json({
-        error: "Validation failed",
-        details: "Field 'url' is required for reachable peer servers",
-        field: "url",
-      });
-  }
-
-  const dbUnreachable = unreachable ? 1 : 0;
-
-  try {
-    const existing = db.prepare("SELECT id FROM servers WHERE id = ?").get(id);
-    if (existing) {
-      if (apiKey !== undefined) {
-        db.prepare(
-          "UPDATE servers SET label = ?, url = ?, parentId = ?, type = ?, unreachable = ?, platform_type = ?, remote_api_key = ? WHERE id = ?"
-        ).run(
-          label,
-          url,
-          parentId || null,
-          type,
-          dbUnreachable,
-          platform_type,
-          apiKey || null,
-          id
-        );
-      } else {
-        db.prepare(
-          "UPDATE servers SET label = ?, url = ?, parentId = ?, type = ?, unreachable = ?, platform_type = ? WHERE id = ?"
-        ).run(
-          label,
-          url,
-          parentId || null,
-          type,
-          dbUnreachable,
-          platform_type,
-          id
-        );
-      }
-      logger.info(`Server updated successfully. ID: ${id}, Label: "${label}"`);
-      res.status(200).json({ message: "Server updated successfully", id });
-    } else {
-      db.prepare(
-        "INSERT INTO servers (id, label, url, parentId, type, unreachable, platform_type, remote_api_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-      ).run(
-        id,
-        label,
-        url,
-        parentId || null,
-        type,
-        dbUnreachable,
-        platform_type,
-        apiKey || null
-      );
-      logger.info(`Server added successfully. ID: ${id}, Label: "${label}"`);
-      res.status(201).json({ message: "Server added successfully", id });
-    }
-  } catch (error) {
-    logger.error(`Database error in POST /api/servers (ID: ${id}): ${error.message}`);
-    logger.debug("Stack trace:", error.stack || "");
-    if (error.message.includes("UNIQUE constraint failed")) {
-      return res
-        .status(409)
-        .json({ error: `Server with ID '${id}' already exists.` });
-    }
-    if (
-      error.message.toLowerCase().includes("can only bind") ||
-      error.message.toLowerCase().includes("datatype mismatch")
-    ) {
-      logger.error(
-        `Possible data binding/type issue for server ID ${id}. Payload received: ${JSON.stringify(req.body)}`
-      );
-      return res
-        .status(500)
-        .json({
-          error: "Failed to save server due to data type issue.",
-          details: error.message,
-        });
-    }
-    res
-      .status(500)
-      .json({ error: "Failed to save server", details: error.message });
-  }
-});
 
 app.delete("/api/servers/:id", requireAuth, validateServerIdParam, (req, res) => {
   const serverId = req.params.id;

--- a/backend/lib/db/servers-migrations.js
+++ b/backend/lib/db/servers-migrations.js
@@ -1,0 +1,47 @@
+function addPlatformColumns(db, logger, columnNames) {
+  if (!columnNames.includes("platform")) {
+    logger.info("Migrating database: Adding platform column to servers table");
+    db.prepare(
+      "ALTER TABLE servers ADD COLUMN platform TEXT DEFAULT 'standard'"
+    ).run();
+  }
+  if (!columnNames.includes("platform_config")) {
+    logger.info("Migrating database: Adding platform_config column to servers table");
+    db.prepare("ALTER TABLE servers ADD COLUMN platform_config TEXT").run();
+  }
+  if (!columnNames.includes("platform_type")) {
+    logger.info("Migrating database: Adding platform_type column to servers table");
+    db.prepare(
+      "ALTER TABLE servers ADD COLUMN platform_type TEXT DEFAULT 'auto'"
+    ).run();
+  }
+}
+
+function addPositionColumn(db, logger, columnNames) {
+  if (columnNames.includes("position")) return;
+  logger.info(
+    "Migrating database: Adding position column to servers table and backfilling sibling order"
+  );
+  db.prepare("ALTER TABLE servers ADD COLUMN position INTEGER").run();
+  const rows = db
+    .prepare("SELECT id, parentId FROM servers ORDER BY rowid ASC")
+    .all();
+  const counters = new Map();
+  const update = db.prepare("UPDATE servers SET position = ? WHERE id = ?");
+  const tx = db.transaction((batch) => {
+    for (const row of batch) {
+      const key = row.parentId || "__root__";
+      const next = counters.get(key) || 0;
+      update.run(next, row.id);
+      counters.set(key, next + 1);
+    }
+  });
+  tx(rows);
+}
+
+function migrateServersInPlace(db, logger, columnNames) {
+  addPlatformColumns(db, logger, columnNames);
+  addPositionColumn(db, logger, columnNames);
+}
+
+module.exports = { migrateServersInPlace };

--- a/backend/routes/servers.js
+++ b/backend/routes/servers.js
@@ -1,0 +1,205 @@
+function listHandler({ db, logger }) {
+  return (req, res) => {
+    logger.debug("GET /api/servers");
+    try {
+      const stmt = db.prepare(
+        "SELECT id, label, url, parentId, type, unreachable, platform_type, position, (remote_api_key IS NOT NULL) as hasApiKey FROM servers ORDER BY (position IS NULL) ASC, position ASC, label COLLATE NOCASE ASC"
+      );
+      const servers = stmt.all();
+      logger.debug(`Returning ${servers.length} servers`);
+      res.json(servers);
+    } catch (error) {
+      logger.error("Failed to get servers:", error.message);
+      logger.debug("Stack trace:", error.stack || "");
+      res
+        .status(500)
+        .json({ error: "Failed to retrieve servers", details: error.message });
+    }
+  };
+}
+
+function updateExistingServer(db, payload) {
+  const { id, label, url, parentId, type, dbUnreachable, platform_type, apiKey } = payload;
+  if (apiKey !== undefined) {
+    db.prepare(
+      "UPDATE servers SET label = ?, url = ?, parentId = ?, type = ?, unreachable = ?, platform_type = ?, remote_api_key = ? WHERE id = ?"
+    ).run(
+      label,
+      url,
+      parentId || null,
+      type,
+      dbUnreachable,
+      platform_type,
+      apiKey || null,
+      id
+    );
+    return;
+  }
+  db.prepare(
+    "UPDATE servers SET label = ?, url = ?, parentId = ?, type = ?, unreachable = ?, platform_type = ? WHERE id = ?"
+  ).run(label, url, parentId || null, type, dbUnreachable, platform_type, id);
+}
+
+function insertNewServer(db, payload) {
+  const { id, label, url, parentId, type, dbUnreachable, platform_type, apiKey } = payload;
+  const nextPositionRow = db
+    .prepare(
+      "SELECT COALESCE(MAX(position), -1) + 1 AS next FROM servers WHERE (parentId IS ? OR parentId = ?)"
+    )
+    .get(parentId || null, parentId || null);
+  const nextPosition = nextPositionRow ? nextPositionRow.next : 0;
+  db.prepare(
+    "INSERT INTO servers (id, label, url, parentId, type, unreachable, platform_type, remote_api_key, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+  ).run(
+    id,
+    label,
+    url,
+    parentId || null,
+    type,
+    dbUnreachable,
+    platform_type,
+    apiKey || null,
+    nextPosition
+  );
+}
+
+function handleUpsertError(error, id, body, logger, res) {
+  logger.error(`Database error in POST /api/servers (ID: ${id}): ${error.message}`);
+  logger.debug("Stack trace:", error.stack || "");
+  if (error.message.includes("UNIQUE constraint failed")) {
+    return res.status(409).json({ error: `Server with ID '${id}' already exists.` });
+  }
+  const lower = error.message.toLowerCase();
+  if (lower.includes("can only bind") || lower.includes("datatype mismatch")) {
+    logger.error(
+      `Possible data binding/type issue for server ID ${id}. Payload received: ${JSON.stringify(body)}`
+    );
+    return res
+      .status(500)
+      .json({ error: "Failed to save server due to data type issue.", details: error.message });
+  }
+  return res.status(500).json({ error: "Failed to save server", details: error.message });
+}
+
+function upsertHandler({ db, logger }) {
+  return (req, res) => {
+    const { id, label, url, parentId, type, unreachable, platform_type, apiKey } = req.body;
+    if (!id) {
+      return res.status(400).json({ error: "Field 'id' is required" });
+    }
+    if (type === "peer" && !unreachable && (!url || url.trim().length === 0)) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details: "Field 'url' is required for reachable peer servers",
+        field: "url",
+      });
+    }
+    const dbUnreachable = unreachable ? 1 : 0;
+    const payload = { id, label, url, parentId, type, dbUnreachable, platform_type, apiKey };
+    try {
+      const existing = db.prepare("SELECT id FROM servers WHERE id = ?").get(id);
+      if (existing) {
+        updateExistingServer(db, payload);
+        logger.info(`Server updated successfully. ID: ${id}, Label: "${label}"`);
+        return res.status(200).json({ message: "Server updated successfully", id });
+      }
+      insertNewServer(db, payload);
+      logger.info(`Server added successfully. ID: ${id}, Label: "${label}"`);
+      return res.status(201).json({ message: "Server added successfully", id });
+    } catch (error) {
+      return handleUpsertError(error, id, req.body, logger, res);
+    }
+  };
+}
+
+function normalizeReorderItems(rawItems) {
+  const out = [];
+  for (const raw of rawItems) {
+    if (!raw || typeof raw.id !== "string" || raw.id.length === 0) {
+      return { error: "Every item must include a string 'id'" };
+    }
+    const position = Number(raw.position);
+    if (!Number.isFinite(position) || position < 0) {
+      return { error: `Invalid position for id '${raw.id}'` };
+    }
+    const parentId =
+      raw.parentId === undefined || raw.parentId === null || raw.parentId === ""
+        ? null
+        : String(raw.parentId);
+    out.push({ id: raw.id, parentId, position: Math.floor(position) });
+  }
+  return { items: out };
+}
+
+function validateReorderItems(items, known) {
+  for (const item of items) {
+    if (!known.has(item.id)) return { error: `Server '${item.id}' not found`, status: 404 };
+    if (item.parentId !== null && !known.has(item.parentId)) {
+      return { error: `parentId '${item.parentId}' does not exist`, status: 400 };
+    }
+    if (item.parentId === item.id) {
+      return { error: `Server '${item.id}' cannot be its own parent`, status: 400 };
+    }
+  }
+  return { ok: true };
+}
+
+function detectReorderCycles(items, known) {
+  const pending = new Map(known);
+  for (const item of items) pending.set(item.id, item.parentId);
+  for (const item of items) {
+    let cursor = item.parentId;
+    const seen = new Set([item.id]);
+    while (cursor) {
+      if (seen.has(cursor)) return { error: `Move of '${item.id}' would create a cycle` };
+      seen.add(cursor);
+      cursor = pending.get(cursor) || null;
+    }
+  }
+  return { ok: true };
+}
+
+function reorderHandler({ db, logger }) {
+  return (req, res) => {
+    logger.debug("PUT /api/servers/order");
+    const { items: rawItems } = req.body || {};
+    if (!Array.isArray(rawItems) || rawItems.length === 0) {
+      return res.status(400).json({ error: "Body must include non-empty 'items' array" });
+    }
+    const normalized = normalizeReorderItems(rawItems);
+    if (normalized.error) return res.status(400).json({ error: normalized.error });
+    try {
+      const known = new Map(
+        db
+          .prepare("SELECT id, parentId FROM servers")
+          .all()
+          .map((row) => [row.id, row.parentId || null])
+      );
+      const validation = validateReorderItems(normalized.items, known);
+      if (validation.error) return res.status(validation.status).json({ error: validation.error });
+      const cycles = detectReorderCycles(normalized.items, known);
+      if (cycles.error) return res.status(400).json({ error: cycles.error });
+      const update = db.prepare("UPDATE servers SET parentId = ?, position = ? WHERE id = ?");
+      const tx = db.transaction((rows) => {
+        for (const row of rows) update.run(row.parentId, row.position, row.id);
+      });
+      tx(normalized.items);
+      logger.info(`Reordered ${normalized.items.length} servers`);
+      return res.json({ ok: true, count: normalized.items.length });
+    } catch (error) {
+      logger.error(`Error in PUT /api/servers/order: ${error.message}`);
+      return res
+        .status(500)
+        .json({ error: "Failed to reorder servers", details: error.message });
+    }
+  };
+}
+
+function registerServerRoutes(app, deps) {
+  const { requireAuth, validateServerInput } = deps;
+  app.get("/api/servers", requireAuth, listHandler(deps));
+  app.post("/api/servers", requireAuth, validateServerInput, upsertHandler(deps));
+  app.put("/api/servers/order", requireAuth, reorderHandler(deps));
+}
+
+module.exports = { registerServerRoutes };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "1.2.1",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-dialog": "^1.1.13",
@@ -351,6 +354,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.13",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import { ChangePasswordPage } from "./components/auth/ChangePasswordPage";
 import { BarChart3 } from "lucide-react";
 import Logger from "./lib/logger";
 import { useWhatsNew } from "./lib/hooks/useWhatsNew";
+import { useReorderServers } from "./hooks/useReorderServers";
 import { useKeyboardShortcuts } from "./lib/hooks/useKeyboardShortcuts";
 import { useSidebarLayout } from "./lib/hooks/useSidebarLayout";
 import { useKonamiHackerMode } from "./lib/hooks/useKonamiHackerMode";
@@ -49,12 +50,10 @@ const logger = new Logger('App');
 export default function App() {
   const auth = useAuth();
   const { shouldShowButton: shouldShowWhatsNewButton, handleShow: handleShowWhatsNew, getModalProps: getWhatsNewModalProps } = useWhatsNew();
-  
   const [groups, setGroups] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [hostOverride, setHostOverride] = useState(null);
-  
   const [noteModalOpen, setNoteModalOpen] = useState(false);
   const [modalSrvId, setModalSrvId] = useState("");
   const [modalPort, setModalPort] = useState(null);
@@ -290,14 +289,12 @@ export default function App() {
       setAutoxposePorts(null);
       return;
     }
-    
     const fetchServices = async () => {
       try {
         const [servicesData, domainData] = await Promise.all([
           getAutoxposeServices(),
           getAutoxposeDomain(),
         ]);
-        
         const services = servicesData?.services || [];
         const domain = domainData?.domain;
         
@@ -1530,6 +1527,7 @@ export default function App() {
       .catch(logger.error);
   }, []);
 
+  const handleReorder = useReorderServers({ servers, groups, setServers, setGroups });
   const addServer = useCallback(
     async (serverData, isUpdate = false) => {
       if (isUpdate) {
@@ -2056,6 +2054,7 @@ export default function App() {
           onSelect={handleSelectServer}
           addServer={addServer}
           deleteServer={deleteServer}
+          onReorder={handleReorder}
           loading={loading}
           hostOverride={hostOverride}
           sidebarLayout={sidebarLayout}

--- a/frontend/src/components/layout/AppSidebarLayout.jsx
+++ b/frontend/src/components/layout/AppSidebarLayout.jsx
@@ -14,6 +14,7 @@ export function AppSidebarLayout({
   onSelect,
   addServer,
   deleteServer,
+  onReorder,
   loading,
   hostOverride,
   sidebarLayout,
@@ -41,6 +42,7 @@ export function AppSidebarLayout({
           onSelect={onSelect}
           onAdd={addServer}
           onDelete={deleteServer}
+          onReorder={onReorder}
           loading={loading}
           hostOverride={hostOverride}
           lastRefreshedAt={sidebarLayout.lastRefreshedAt}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -7,6 +7,8 @@ import {
   Loader2,
   AlertCircle,
 } from "lucide-react";
+import { DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter } from "@dnd-kit/core";
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -21,7 +23,10 @@ import {
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
 import { SidebarSkeleton } from "./SidebarSkeleton";
-import { ServerCard } from "./ServerCard";
+import { SortableServerCard } from "./SortableServerCard";
+import { SidebarSortChip } from "./SidebarSortChip";
+import { buildSidebarTree, sortByLabel, computeReorderItems } from "@/lib/sidebar-tree";
+import { useSidebarSortMode } from "@/hooks/useSidebarSortMode";
 
 const generateServerId = (label) => {
   if (!label || !label.trim()) {
@@ -46,6 +51,7 @@ export function Sidebar({
   onSelect,
   onAdd,
   onDelete,
+  onReorder,
   loading,
   hostOverride,
   lastRefreshedAt = {},
@@ -69,6 +75,13 @@ export function Sidebar({
   const [submitting, setSubmitting] = useState(false);
   const [validationStatus, setValidationStatus] = useState(null);
   const latestValidationRef = useRef(0);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const { sortMode, setSortMode, undoState, undoToPrevious } = useSidebarSortMode();
 
   useEffect(() => {
     if (!requestedMode) {
@@ -325,25 +338,18 @@ export function Sidebar({
     return <SidebarSkeleton />;
   }
 
-  const serverMap = new Map(servers.map((s) => [s.id, s]));
-  const topLevelServers = [];
-  const childrenMap = new Map();
-
-  servers.forEach((server) => {
-    if (server.parentId && serverMap.has(server.parentId)) {
-      const children = childrenMap.get(server.parentId) || [];
-      children.push(server);
-      childrenMap.set(server.parentId, children);
-    } else {
-      topLevelServers.push(server);
-    }
-  });
+  const tree = buildSidebarTree(servers);
+  const { topLevelServers, childrenMap } = tree;
+  const dragEnabled = Boolean(onReorder) && sortMode === "custom";
+  const displayedTopLevel = sortByLabel(topLevelServers, sortMode);
 
   const renderServerHierarchy = (server, level = 0) => {
     const children = childrenMap.get(server.id) || [];
+    const displayedChildren = sortByLabel(children, sortMode);
     const maxIndentLevel = 3;
+    const childIds = displayedChildren.map((c) => c.id);
     return (
-      <ServerCard
+      <SortableServerCard
         key={server.id}
         server={server}
         isSelected={selectedId === server.id}
@@ -352,15 +358,26 @@ export function Sidebar({
         onDelete={setServerToDelete}
         hostOverride={hostOverride}
         lastRefreshedTs={lastRefreshedAt[server.id]}
+        draggable={dragEnabled}
       >
-        {children.length > 0 && level < maxIndentLevel && (
+        {displayedChildren.length > 0 && level < maxIndentLevel && (
           <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700/50 space-y-3">
-            {children.map((child) => renderServerHierarchy(child, level + 1))}
+            <SortableContext items={childIds} strategy={verticalListSortingStrategy}>
+              {displayedChildren.map((child) => renderServerHierarchy(child, level + 1))}
+            </SortableContext>
           </div>
         )}
-      </ServerCard>
+      </SortableServerCard>
     );
   };
+
+  const handleDragEnd = (event) => {
+    if (!onReorder || !dragEnabled) return;
+    const items = computeReorderItems(event.active, event.over, tree);
+    if (items) onReorder(items);
+  };
+
+  const topLevelIds = displayedTopLevel.map((s) => s.id);
 
   return (
     <div className="flex flex-col h-full bg-white dark:bg-slate-900">
@@ -381,8 +398,25 @@ export function Sidebar({
             </h3>
           </div>
           <div className="flex-1 overflow-y-auto px-6 space-y-4 pb-4">
-            {!loading &&
-              topLevelServers.map((server) => renderServerHierarchy(server))}
+            {!loading && (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={topLevelIds} strategy={verticalListSortingStrategy}>
+                  {displayedTopLevel.map((server) => renderServerHierarchy(server))}
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
+          <div className="px-6 pt-2 flex-shrink-0">
+            <SidebarSortChip
+              sortMode={sortMode}
+              onChange={setSortMode}
+              undoState={undoState}
+              onUndo={undoToPrevious}
+            />
           </div>
           <div className="p-6 mt-auto flex-shrink-0">
             <button

--- a/frontend/src/components/layout/SidebarSortChip.jsx
+++ b/frontend/src/components/layout/SidebarSortChip.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { ArrowDownAZ, ArrowDownZA, ListOrdered, Undo2 } from "lucide-react";
+
+const MODE_LABEL = { custom: "Custom", asc: "A-Z", desc: "Z-A" };
+const NEXT_MODE = { custom: "asc", asc: "desc", desc: "custom" };
+const MODE_ICON = {
+  custom: ListOrdered,
+  asc: ArrowDownAZ,
+  desc: ArrowDownZA,
+};
+
+export function SidebarSortChip({ sortMode, onChange, undoState, onUndo }) {
+  const Icon = MODE_ICON[sortMode] || ListOrdered;
+  const cycle = () => onChange(NEXT_MODE[sortMode] || "custom");
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={cycle}
+        className="w-full inline-flex items-center justify-center gap-1.5 rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 px-3 py-1.5 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+        aria-label={`Sidebar order: ${MODE_LABEL[sortMode]}. Click to change.`}
+      >
+        <Icon className="h-3.5 w-3.5" />
+        <span>Order: {MODE_LABEL[sortMode]}</span>
+      </button>
+      {undoState.visible && (
+        <div
+          role="status"
+          className={`flex items-center justify-between gap-2 rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 px-3 py-1.5 text-xs text-slate-600 dark:text-slate-300 transition-all duration-200 ease-out ${
+            undoState.closing ? "opacity-0 -translate-y-1" : "opacity-100 translate-y-0"
+          }`}
+        >
+          <span className="truncate">
+            Switched to {MODE_LABEL[sortMode]}.
+          </span>
+          <button
+            type="button"
+            onClick={onUndo}
+            className="inline-flex items-center gap-1 rounded px-1 py-0.5 font-medium text-slate-700 dark:text-slate-200 hover:text-slate-900 dark:hover:text-slate-50 hover:underline"
+          >
+            <Undo2 className="h-3 w-3" />
+            Back to {MODE_LABEL[undoState.previousMode] || "Custom"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/SortableServerCard.jsx
+++ b/frontend/src/components/layout/SortableServerCard.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import { ServerCard } from "./ServerCard";
+
+export function SortableServerCard({
+  server,
+  isSelected,
+  onSelect,
+  onEdit,
+  onDelete,
+  hostOverride,
+  lastRefreshedTs,
+  draggable,
+  children,
+}) {
+  const sortable = useSortable({ id: server.id, disabled: !draggable });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = sortable;
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const dragHandleProps = draggable ? { ...attributes, ...listeners } : null;
+
+  return (
+    <div ref={setNodeRef} style={style} className="group relative">
+      {dragHandleProps && (
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={(e) => e.stopPropagation()}
+          className="absolute -left-5 top-1/2 -translate-y-1/2 p-1 rounded text-slate-400 dark:text-slate-500 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-slate-600 dark:hover:text-slate-300 cursor-grab active:cursor-grabbing transition-opacity z-10"
+          aria-label="Drag to reorder"
+          {...dragHandleProps}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      )}
+      <ServerCard
+        server={server}
+        isSelected={isSelected}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        hostOverride={hostOverride}
+        lastRefreshedTs={lastRefreshedTs}
+      >
+        {children}
+      </ServerCard>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useReorderServers.js
+++ b/frontend/src/hooks/useReorderServers.js
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+import Logger from "@/lib/logger";
+
+const logger = new Logger("useReorderServers");
+
+export function useReorderServers({ servers, groups, setServers, setGroups }) {
+  return useCallback(
+    async (items) => {
+      const itemMap = new Map(items.map((it) => [it.id, it.position]));
+      const reorder = (list) =>
+        [...list].sort((a, b) => {
+          const ap = itemMap.has(a.id) ? itemMap.get(a.id) : Number.POSITIVE_INFINITY;
+          const bp = itemMap.has(b.id) ? itemMap.get(b.id) : Number.POSITIVE_INFINITY;
+          return ap - bp;
+        });
+      const prevServers = servers;
+      const prevGroups = groups;
+      setServers((cur) => reorder(cur));
+      setGroups((cur) => reorder(cur));
+      try {
+        const r = await fetch("/api/servers/order", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ items }),
+        });
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body.error || `reorder failed: ${r.status}`);
+        }
+      } catch (err) {
+        logger.error("Failed to persist reorder:", err);
+        setServers(prevServers);
+        setGroups(prevGroups);
+      }
+    },
+    [servers, groups, setServers, setGroups]
+  );
+}

--- a/frontend/src/hooks/useSidebarSortMode.js
+++ b/frontend/src/hooks/useSidebarSortMode.js
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "portracker.sidebarSortMode.v1";
+const VALID_MODES = new Set(["custom", "asc", "desc"]);
+const UNDO_VISIBLE_MS = 5000;
+const UNDO_FADE_MS = 200;
+
+function readStoredMode() {
+  if (typeof window === "undefined") return "custom";
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return VALID_MODES.has(v) ? v : "custom";
+  } catch {
+    return "custom";
+  }
+}
+
+function persistMode(mode) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    return;
+  }
+}
+
+export function useSidebarSortMode() {
+  const [sortMode, setSortModeState] = useState(readStoredMode);
+  const [undoState, setUndoState] = useState({
+    visible: false,
+    closing: false,
+    previousMode: "custom",
+  });
+  const fadeTimerRef = useRef(null);
+  const hideTimerRef = useRef(null);
+
+  const clearTimers = useCallback(() => {
+    if (fadeTimerRef.current) {
+      clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = null;
+    }
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const setSortMode = useCallback(
+    (next) => {
+      if (!VALID_MODES.has(next) || next === sortMode) return;
+      const previous = sortMode;
+      setSortModeState(next);
+      persistMode(next);
+      clearTimers();
+      if (next !== "custom") {
+        setUndoState({ visible: true, closing: false, previousMode: previous });
+        fadeTimerRef.current = setTimeout(() => {
+          setUndoState((s) => ({ ...s, closing: true }));
+          fadeTimerRef.current = null;
+        }, UNDO_VISIBLE_MS);
+        hideTimerRef.current = setTimeout(() => {
+          setUndoState((s) => ({ ...s, visible: false, closing: false }));
+          hideTimerRef.current = null;
+        }, UNDO_VISIBLE_MS + UNDO_FADE_MS);
+      } else {
+        setUndoState({ visible: false, closing: false, previousMode: "custom" });
+      }
+    },
+    [sortMode, clearTimers]
+  );
+
+  const undoToPrevious = useCallback(() => {
+    clearTimers();
+    setSortModeState(undoState.previousMode);
+    persistMode(undoState.previousMode);
+    setUndoState({ visible: false, closing: false, previousMode: "custom" });
+  }, [undoState.previousMode, clearTimers]);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  return { sortMode, setSortMode, undoState, undoToPrevious };
+}

--- a/frontend/src/lib/autoxpose-nudge.js
+++ b/frontend/src/lib/autoxpose-nudge.js
@@ -75,7 +75,14 @@ function matchesService(serviceName) {
 export function findEligibleService(servers) {
   if (!servers?.length) return null;
 
-  for (const server of servers) {
+  const ordered = [...servers].sort((a, b) => {
+    const ap = Number.isFinite(a?.position) ? a.position : Number.POSITIVE_INFINITY;
+    const bp = Number.isFinite(b?.position) ? b.position : Number.POSITIVE_INFINITY;
+    if (ap !== bp) return ap - bp;
+    return String(a?.id || '').localeCompare(String(b?.id || ''));
+  });
+
+  for (const server of ordered) {
     const ports = server.data || server.ports || [];
     for (const port of ports) {
       const rawName = port.customServiceName || port.originalServiceName || port.owner;

--- a/frontend/src/lib/sidebar-tree.js
+++ b/frontend/src/lib/sidebar-tree.js
@@ -1,0 +1,44 @@
+export function buildSidebarTree(servers) {
+  const serverMap = new Map(servers.map((s) => [s.id, s]));
+  const topLevelServers = [];
+  const childrenMap = new Map();
+  servers.forEach((server) => {
+    if (server.parentId && serverMap.has(server.parentId)) {
+      const children = childrenMap.get(server.parentId) || [];
+      children.push(server);
+      childrenMap.set(server.parentId, children);
+    } else {
+      topLevelServers.push(server);
+    }
+  });
+  return { serverMap, topLevelServers, childrenMap };
+}
+
+export function sortByLabel(list, mode) {
+  if (mode !== "asc" && mode !== "desc") return list;
+  const sorted = [...list].sort((a, b) =>
+    String(a.label || a.id || "").localeCompare(String(b.label || b.id || ""), undefined, {
+      sensitivity: "base",
+    })
+  );
+  return mode === "desc" ? sorted.reverse() : sorted;
+}
+
+export function computeReorderItems(active, over, tree) {
+  if (!active || !over || active.id === over.id) return null;
+  const { serverMap, topLevelServers, childrenMap } = tree;
+  const activeServer = serverMap.get(active.id);
+  const overServer = serverMap.get(over.id);
+  if (!activeServer || !overServer) return null;
+  const activeParent = activeServer.parentId || null;
+  const overParent = overServer.parentId || null;
+  if (activeParent !== overParent) return null;
+  const siblings = activeParent ? childrenMap.get(activeParent) || [] : topLevelServers;
+  const oldIndex = siblings.findIndex((s) => s.id === active.id);
+  const newIndex = siblings.findIndex((s) => s.id === over.id);
+  if (oldIndex < 0 || newIndex < 0) return null;
+  const reordered = [...siblings];
+  const [moved] = reordered.splice(oldIndex, 1);
+  reordered.splice(newIndex, 0, moved);
+  return reordered.map((s, idx) => ({ id: s.id, parentId: activeParent, position: idx }));
+}


### PR DESCRIPTION
## Summary

Drag-and-drop reordering for sidebar servers, plus alphabetical view modes with non-destructive switching.

### Backend
- **Position Column**: New `position` column on `servers` with backfill migration; insert paths assign next sibling position.
- **Reorder Endpoint**: `PUT /api/servers/order` validates parents, blocks cycles, and persists positions transactionally.
- **Stable Order**: `/api/servers` and `/api/all-ports` share `ORDER BY (position IS NULL) ASC, position ASC, label COLLATE NOCASE ASC`.

### Frontend
- **Drag-and-Drop**: `@dnd-kit` powered reordering with pointer and keyboard support; drag handles render only in Custom mode (resolves #9).
- **Sort Modes**: Sidebar chip cycles Custom -> A-Z -> Z-A. Alphabetical modes are view-only and do not mutate `position`.
- **Inline Undo**: Switching sort modes shows an 8-second "Back to Previous" banner that restores the prior mode.
- **Optimistic Reorder**: `useReorderServers` updates both `servers` and `groups` from the same item map and rolls back both on API failure.
- **Priority-Aware Suggestions**: Autoxpose nudge picks the highest-position eligible server regardless of view mode.
